### PR TITLE
Cosmos DB analytics + Leaderboard tab

### DIFF
--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -17,6 +17,7 @@ import type { YtmSections } from './components/HomePanel';
 import { AlbumPanel } from './components/AlbumPanel';
 import { ArtistPanel } from './components/ArtistPanel';
 import { ContainerPanel } from './components/ContainerPanel';
+import { LeaderboardPanel } from './components/LeaderboardPanel';
 import { QueueSidebar } from './components/QueueSidebar';
 import { MiniPlayerShell } from './components/MiniPlayer';
 import { DisplayNameModal } from './components/DisplayNameModal';
@@ -148,7 +149,9 @@ function MainApp() {
     if (uri) {
       const trackName = getName(normalized);
       const artist = normalized.track?.primaryArtist?.name ?? normalized.track?.artist?.name ?? '';
-      window.sonos.publishQueued({ uri, trackName, artist }).catch(() => { /* silent */ });
+      const album = typeof normalized.track?.album === 'object' ? normalized.track.album?.name : undefined;
+      const imageUrl = normalized.track?.imageUrl ?? undefined;
+      window.sonos.publishQueued({ uri, trackName, artist, album, imageUrl }).catch(() => { /* silent */ });
     }
 
     if (!isSingleTrack) {
@@ -210,7 +213,8 @@ function MainApp() {
           <Route path="/search" element={<HomePanel isAuthed={isAuthed} onAddToQueue={handleAddToQueue} ytm={ytm} ytmLoading={ytmLoading} history={history} histLoading={histLoading} />} />
           <Route path="/album/:id"  element={<AlbumPanel onAddToQueue={handleAddToQueue} />} />
           <Route path="/artist/:id" element={<ArtistPanel onAddToQueue={handleAddToQueue} />} />
-          <Route path="/container/:id" element={<ContainerPanel onAddToQueue={handleAddToQueue} />} />
+          <Route path="/container/:id"  element={<ContainerPanel onAddToQueue={handleAddToQueue} />} />
+          <Route path="/leaderboard"    element={<LeaderboardPanel />} />
         </Routes>
       </div>
       <QueueSidebar

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -151,7 +151,9 @@ function MainApp() {
       const artist = normalized.track?.primaryArtist?.name ?? normalized.track?.artist?.name ?? '';
       const album = typeof normalized.track?.album === 'object' ? normalized.track.album?.name : undefined;
       const imageUrl = normalized.track?.imageUrl ?? undefined;
-      window.sonos.publishQueued({ uri, trackName, artist, album, imageUrl }).catch(() => { /* silent */ });
+      const serviceId = body.id.serviceId ?? '';
+      const accountId = body.id.accountId ?? '';
+      window.sonos.publishQueued({ uri, trackName, artist, album, imageUrl, serviceId, accountId }).catch(() => { /* silent */ });
     }
 
     if (!isSingleTrack) {

--- a/renderer/src/components/LeaderboardPanel.tsx
+++ b/renderer/src/components/LeaderboardPanel.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useStats, StatsPeriod } from '../hooks/useStats';
+import styles from '../styles/LeaderboardPanel.module.css';
+
+const PERIODS: { value: StatsPeriod; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'week',  label: 'This week' },
+  { value: 'alltime', label: 'All time' },
+];
+
+const MEDALS = ['🥇', '🥈', '🥉'];
+
+export function LeaderboardPanel() {
+  const [period, setPeriod] = useState<StatsPeriod>('week');
+  const { data, isLoading, error, refetch } = useStats(period);
+
+  const maxUserCount = data?.topUsers[0]?.count ?? 1;
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>Leaderboard</h1>
+        <div className={styles.periodTabs}>
+          {PERIODS.map(p => (
+            <button
+              key={p.value}
+              className={`${styles.periodBtn}${period === p.value ? ' ' + styles.active : ''}`}
+              onClick={() => setPeriod(p.value)}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+        <button className={styles.refreshBtn} onClick={() => refetch()} title="Refresh">↺</button>
+      </div>
+
+      {isLoading && <div className={styles.state}>Loading…</div>}
+      {(error || data?.error) && (
+        <div className={styles.state}>
+          {data?.error ?? 'Failed to load stats'}
+        </div>
+      )}
+
+      {data && !data.error && !isLoading && (
+        <div className={styles.body}>
+          {/* ── Top queuers ── */}
+          <section className={styles.section}>
+            <h2 className={styles.sectionTitle}>Top queuers</h2>
+            {data.topUsers.length === 0
+              ? <div className={styles.empty}>No data yet for this period</div>
+              : data.topUsers.map((u, i) => (
+                <div key={u.userId} className={styles.userRow}>
+                  <span className={styles.rank}>
+                    {i < 3 ? MEDALS[i] : <span className={styles.rankNum}>{i + 1}</span>}
+                  </span>
+                  <span className={styles.userName}>{u.userId}</span>
+                  <div className={styles.barWrap}>
+                    <div
+                      className={styles.bar}
+                      style={{ width: `${Math.round((u.count / maxUserCount) * 100)}%` }}
+                    />
+                  </div>
+                  <span className={styles.count}>{u.count}</span>
+                </div>
+              ))
+            }
+          </section>
+
+          <div className={styles.columns}>
+            {/* ── Top tracks ── */}
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Top tracks</h2>
+              {data.topTracks.length === 0
+                ? <div className={styles.empty}>No data yet</div>
+                : data.topTracks.map((t, i) => (
+                  <div key={i} className={styles.trackRow}>
+                    {t.imageUrl
+                      ? <img className={styles.art} src={t.imageUrl} alt="" loading="lazy" />
+                      : <div className={styles.artPlaceholder} />
+                    }
+                    <div className={styles.trackInfo}>
+                      <span className={styles.trackName}>{t.trackName}</span>
+                      <span className={styles.trackSub}>
+                        {t.artist}{t.album ? ` · ${t.album}` : ''}
+                      </span>
+                    </div>
+                    <span className={styles.count}>{t.count}×</span>
+                  </div>
+                ))
+              }
+            </section>
+
+            {/* ── Top artists ── */}
+            <section className={styles.section}>
+              <h2 className={styles.sectionTitle}>Top artists</h2>
+              {data.topArtists.length === 0
+                ? <div className={styles.empty}>No data yet</div>
+                : data.topArtists.map((a, i) => (
+                  <div key={i} className={styles.artistRow}>
+                    <span className={styles.rankNum}>{i + 1}</span>
+                    <span className={styles.artistName}>{a.artist}</span>
+                    <span className={styles.count}>{a.count}×</span>
+                  </div>
+                ))
+              }
+            </section>
+          </div>
+
+          <div className={styles.footer}>
+            {data.totalEvents} queue events{data.periodStart > 0 ? ` since ${new Date(data.periodStart).toLocaleDateString()}` : ' total'}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/renderer/src/components/LeaderboardPanel.tsx
+++ b/renderer/src/components/LeaderboardPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useStats, StatsPeriod } from '../hooks/useStats';
 import styles from '../styles/LeaderboardPanel.module.css';
 
@@ -10,11 +11,22 @@ const PERIODS: { value: StatsPeriod; label: string }[] = [
 
 const MEDALS = ['🥇', '🥈', '🥉'];
 
+function makeDragItem(t: StatsTrack) {
+  return JSON.stringify([{
+    type: 'TRACK',
+    name: t.trackName,
+    artist: t.artist,
+    imageUrl: t.imageUrl,
+    id: { objectId: t.uri, serviceId: t.serviceId ?? '', accountId: t.accountId ?? '' },
+  }]);
+}
+
 export function LeaderboardPanel() {
   const [period, setPeriod] = useState<StatsPeriod>('week');
   const { data, isLoading, error, refetch } = useStats(period);
+  const navigate = useNavigate();
 
-  const maxUserCount = data?.topUsers[0]?.count ?? 1;
+  const maxUserCount = data?.topUsers?.[0]?.count ?? 1;
 
   return (
     <div className={styles.page}>
@@ -73,7 +85,15 @@ export function LeaderboardPanel() {
               {data.topTracks.length === 0
                 ? <div className={styles.empty}>No data yet</div>
                 : data.topTracks.map((t, i) => (
-                  <div key={i} className={styles.trackRow}>
+                  <div
+                    key={i}
+                    className={styles.trackRow}
+                    draggable
+                    onDragStart={(e) => {
+                      e.dataTransfer.effectAllowed = 'copy';
+                      e.dataTransfer.setData('application/sonos-item-list', makeDragItem(t));
+                    }}
+                  >
                     {t.imageUrl
                       ? <img className={styles.art} src={t.imageUrl} alt="" loading="lazy" />
                       : <div className={styles.artPlaceholder} />
@@ -81,7 +101,21 @@ export function LeaderboardPanel() {
                     <div className={styles.trackInfo}>
                       <span className={styles.trackName}>{t.trackName}</span>
                       <span className={styles.trackSub}>
-                        {t.artist}{t.album ? ` · ${t.album}` : ''}
+                        {t.artist
+                          ? <button
+                              className={styles.artistLink}
+                              onClick={(e) => { e.stopPropagation(); navigate(`/search?q=${encodeURIComponent(t.artist)}`); }}
+                            >{t.artist}</button>
+                          : null
+                        }
+                        {t.artist && t.album ? ' · ' : null}
+                        {t.album
+                          ? <button
+                              className={styles.artistLink}
+                              onClick={(e) => { e.stopPropagation(); navigate(`/search?q=${encodeURIComponent(t.album!)}`); }}
+                            >{t.album}</button>
+                          : null
+                        }
                       </span>
                     </div>
                     <span className={styles.count}>{t.count}×</span>
@@ -98,7 +132,10 @@ export function LeaderboardPanel() {
                 : data.topArtists.map((a, i) => (
                   <div key={i} className={styles.artistRow}>
                     <span className={styles.rankNum}>{i + 1}</span>
-                    <span className={styles.artistName}>{a.artist}</span>
+                    <button
+                      className={styles.artistLink}
+                      onClick={(e) => { e.stopPropagation(); navigate(`/search?q=${encodeURIComponent(a.artist)}`); }}
+                    >{a.artist}</button>
                     <span className={styles.count}>{a.count}×</span>
                   </div>
                 ))

--- a/renderer/src/components/TopNav.tsx
+++ b/renderer/src/components/TopNav.tsx
@@ -78,8 +78,9 @@ export function TopNav({
     navigate('/');
   };
 
-  const isAtRoot   = location.pathname === '/';
-  const isInSearch = location.pathname === '/search';
+  const isAtRoot        = location.pathname === '/';
+  const isInSearch      = location.pathname === '/search';
+  const isLeaderboard   = location.pathname === '/leaderboard';
 
   return (
     <nav className={styles.nav}>
@@ -101,6 +102,12 @@ export function TopNav({
             onClick={handleClear}
           >
             Home
+          </button>
+          <button
+            className={`${styles.tab}${isLeaderboard ? ' ' + styles.active : ''}`}
+            onClick={() => navigate('/leaderboard')}
+          >
+            Leaderboard
           </button>
           <div className={styles.searchWrap}>
             <input

--- a/renderer/src/hooks/useStats.ts
+++ b/renderer/src/hooks/useStats.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+export type StatsPeriod = 'today' | 'week' | 'alltime';
+
+export function useStats(period: StatsPeriod) {
+  return useQuery<StatsResult>({
+    queryKey: ['stats', period],
+    queryFn: () => window.sonos.fetchStats(period),
+    staleTime: 60_000,
+    retry: 1,
+  });
+}

--- a/renderer/src/styles/LeaderboardPanel.module.css
+++ b/renderer/src/styles/LeaderboardPanel.module.css
@@ -1,0 +1,243 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 28px 16px;
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text);
+  margin-right: 4px;
+}
+
+.periodTabs {
+  display: flex;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 20px;
+  padding: 3px;
+}
+
+.periodBtn {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  padding: 5px 14px;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+.periodBtn:hover { color: var(--text-2); }
+.periodBtn.active { background: rgba(255, 255, 255, 0.12); color: var(--text); }
+
+.refreshBtn {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 5px 8px;
+  border-radius: var(--r-sm);
+  transition: color 0.15s, background 0.15s;
+  line-height: 1;
+  margin-left: auto;
+}
+.refreshBtn:hover { color: var(--text-2); background: var(--bg-2); }
+
+.state {
+  padding: 48px 28px;
+  color: var(--text-3);
+  font-size: 14px;
+  text-align: center;
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sectionTitle {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin-bottom: 4px;
+}
+
+.empty {
+  font-size: 13px;
+  color: var(--text-3);
+  padding: 8px 0;
+}
+
+/* ── User leaderboard row ── */
+.userRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+}
+
+.rank {
+  width: 28px;
+  text-align: center;
+  flex-shrink: 0;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.rankNum {
+  font-size: 13px;
+  color: var(--text-3);
+  font-weight: 500;
+}
+
+.userName {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  width: 120px;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.barWrap {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.bar {
+  height: 100%;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+  min-width: 4px;
+}
+
+.count {
+  font-size: 12px;
+  color: var(--text-3);
+  font-weight: 500;
+  width: 36px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* ── Two-column layout for tracks + artists ── */
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+}
+
+/* ── Track row ── */
+.trackRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 0;
+}
+
+.art {
+  width: 36px;
+  height: 36px;
+  border-radius: 4px;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--bg-2);
+}
+
+.artPlaceholder {
+  width: 36px;
+  height: 36px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  flex-shrink: 0;
+}
+
+.trackInfo {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.trackName {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trackSub {
+  font-size: 11px;
+  color: var(--text-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Artist row ── */
+.artistRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+}
+
+.artistName {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Footer ── */
+.footer {
+  font-size: 11px;
+  color: var(--text-3);
+  padding-top: 4px;
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 600px) {
+  .columns {
+    grid-template-columns: 1fr;
+  }
+}

--- a/renderer/src/styles/LeaderboardPanel.module.css
+++ b/renderer/src/styles/LeaderboardPanel.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 100%;
   overflow: hidden;
 }
 
@@ -166,7 +167,9 @@
   align-items: center;
   gap: 10px;
   padding: 5px 0;
+  cursor: grab;
 }
+.trackRow:active { cursor: grabbing; }
 
 .art {
   width: 36px;
@@ -210,6 +213,19 @@
   white-space: nowrap;
 }
 
+/* ── Clickable artist/album link ── */
+.artistLink {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font-size: inherit;
+  font-family: inherit;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.12s;
+}
+.artistLink:hover { color: var(--text-2); }
+
 /* ── Artist row ── */
 .artistRow {
   display: flex;
@@ -227,6 +243,19 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Artist row link overrides artistLink defaults */
+.artistRow .artistLink {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.artistRow .artistLink:hover { color: var(--text-2); }
 
 /* ── Footer ── */
 .footer {

--- a/renderer/src/types/globals.d.ts
+++ b/renderer/src/types/globals.d.ts
@@ -34,7 +34,7 @@ interface FetchResponse {
 type Unsubscribe = () => void;
 
 interface StatsUser  { userId: string; count: number; }
-interface StatsTrack { trackName: string; artist: string; album?: string; imageUrl?: string; count: number; }
+interface StatsTrack { trackName: string; artist: string; album?: string; imageUrl?: string; uri?: string; serviceId?: string; accountId?: string; count: number; }
 interface StatsArtist { artist: string; count: number; }
 interface StatsResult {
   topUsers: StatsUser[];
@@ -76,7 +76,7 @@ interface SonosPreload {
   // Attribution / office presence
   getDisplayName:     ()                                          => Promise<string | null>;
   setDisplayName:     (name: string)                              => Promise<void>;
-  publishQueued:      (item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string }) => Promise<void>;
+  publishQueued:      (item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string; serviceId?: string; accountId?: string }) => Promise<void>;
   fetchStats:         (period: string) => Promise<StatsResult>;
   refreshAttribution: ()                                           => Promise<void>;
   onAttributionMap:   (cb: (map: AttributionMap) => void)         => Unsubscribe;

--- a/renderer/src/types/globals.d.ts
+++ b/renderer/src/types/globals.d.ts
@@ -33,6 +33,18 @@ interface FetchResponse {
 
 type Unsubscribe = () => void;
 
+interface StatsUser  { userId: string; count: number; }
+interface StatsTrack { trackName: string; artist: string; album?: string; imageUrl?: string; count: number; }
+interface StatsArtist { artist: string; count: number; }
+interface StatsResult {
+  topUsers: StatsUser[];
+  topTracks: StatsTrack[];
+  topArtists: StatsArtist[];
+  totalEvents: number;
+  periodStart: number;
+  error?: string;
+}
+
 interface SonosPreload {
   getVersion: () => Promise<string>;
   onAuthReady: (cb: VoidCallback) => Unsubscribe;
@@ -64,7 +76,8 @@ interface SonosPreload {
   // Attribution / office presence
   getDisplayName:     ()                                          => Promise<string | null>;
   setDisplayName:     (name: string)                              => Promise<void>;
-  publishQueued:      (item: { uri: string; trackName: string; artist: string }) => Promise<void>;
+  publishQueued:      (item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string }) => Promise<void>;
+  fetchStats:         (period: string) => Promise<StatsResult>;
   refreshAttribution: ()                                           => Promise<void>;
   onAttributionMap:   (cb: (map: AttributionMap) => void)         => Unsubscribe;
   onAttributionEvent: (cb: (event: AttributionEvent) => void)     => Unsubscribe;

--- a/server/azuredeploy.json
+++ b/server/azuredeploy.json
@@ -23,6 +23,7 @@
     "webPubSubName": "[concat(parameters('appName'), '-wps')]",
     "hostingPlanName": "[concat(parameters('appName'), '-plan')]",
     "functionAppName": "[concat(parameters('appName'), '-fn')]",
+    "cosmosName": "[concat(parameters('appName'), '-cosmos')]",
     "hubName": "office",
     "containerName": "attribution"
   },
@@ -79,6 +80,42 @@
       }
     },
     {
+      "type": "Microsoft.DocumentDB/databaseAccounts",
+      "apiVersion": "2024-02-15-preview",
+      "name": "[variables('cosmosName')]",
+      "location": "[parameters('location')]",
+      "kind": "GlobalDocumentDB",
+      "properties": {
+        "databaseAccountOfferType": "Standard",
+        "capabilities": [{ "name": "EnableServerless" }],
+        "locations": [{ "locationName": "[parameters('location')]", "failoverPriority": 0 }]
+      }
+    },
+    {
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+      "apiVersion": "2024-02-15-preview",
+      "name": "[concat(variables('cosmosName'), '/truetunes')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosName'))]"
+      ],
+      "properties": { "resource": { "id": "truetunes" } }
+    },
+    {
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+      "apiVersion": "2024-02-15-preview",
+      "name": "[concat(variables('cosmosName'), '/truetunes/events')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', variables('cosmosName'), 'truetunes')]"
+      ],
+      "properties": {
+        "resource": {
+          "id": "events",
+          "partitionKey": { "paths": ["/userId"], "kind": "Hash" },
+          "defaultTtl": 7776000
+        }
+      }
+    },
+    {
       "type": "Microsoft.Web/serverfarms",
       "apiVersion": "2023-01-01",
       "name": "[variables('hostingPlanName')]",
@@ -100,7 +137,8 @@
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
         "[resourceId('Microsoft.Storage/storageAccounts', variables('storageName'))]",
-        "[resourceId('Microsoft.SignalRService/webPubSub', variables('webPubSubName'))]"
+        "[resourceId('Microsoft.SignalRService/webPubSub', variables('webPubSubName'))]",
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosName'))]"
       ],
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
@@ -141,6 +179,18 @@
             {
               "name": "STORAGE_CONNECTION_STRING",
               "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';EndpointSuffix=', environment().suffixes.storage, ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageName')), '2023-01-01').keys[0].value)]"
+            },
+            {
+              "name": "COSMOS_CONNECTION_STRING",
+              "value": "[listConnectionStrings(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosName')), '2024-02-15-preview').connectionStrings[0].connectionString]"
+            },
+            {
+              "name": "COSMOS_DATABASE",
+              "value": "truetunes"
+            },
+            {
+              "name": "COSMOS_CONTAINER",
+              "value": "events"
             }
           ],
           "ftpsState": "Disabled",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "true-tunes-server",
       "version": "1.0.0",
       "dependencies": {
+        "@azure/cosmos": "^4.1.0",
         "@azure/functions": "^4.5.0",
         "@azure/storage-blob": "^12.26.0",
         "@azure/web-pubsub": "^1.1.3"
@@ -15,6 +16,23 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@azure-rest/core-client": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.0.tgz",
+      "integrity": "sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -161,6 +179,28 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@azure/cosmos": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@azure/cosmos/-/cosmos-4.9.2.tgz",
+      "integrity": "sha512-g+n9GDm+N4iMPE3/ZfFClBvy33fE13oa60wJLKof05tEzcJF+4KsVNdjZkRNOTRBvpGGwD0CO/FGdxBuOb2+yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-keys": "^4.9.0",
+        "@azure/logger": "^1.1.4",
+        "fast-json-stable-stringify": "^2.1.0",
+        "priorityqueuejs": "^2.0.0",
+        "semaphore": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@azure/functions": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.12.0.tgz",
@@ -181,6 +221,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0"
+      }
+    },
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-keys": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.0.tgz",
+      "integrity": "sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.0.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/logger": {
@@ -355,6 +437,12 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
@@ -523,6 +611,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/priorityqueuejs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-2.0.0.tgz",
+      "integrity": "sha512-19BMarhgpq3x4ccvVi8k2QpJZcymo/iFUcrhPd4V96kYGovOdTsWwy7fxChYi4QY+m2EnGBWSX9Buakz+tWNQQ==",
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -542,6 +636,14 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "prestart": "npm run build"
   },
   "dependencies": {
+    "@azure/cosmos": "^4.1.0",
     "@azure/functions": "^4.5.0",
     "@azure/storage-blob": "^12.26.0",
     "@azure/web-pubsub": "^1.1.3"

--- a/server/src/functions/log-event.ts
+++ b/server/src/functions/log-event.ts
@@ -9,6 +9,8 @@ interface QueueEvent {
   artist: string;
   album?: string;
   imageUrl?: string;
+  serviceId?: string;
+  accountId?: string;
   timestamp: number;
 }
 
@@ -50,6 +52,8 @@ export async function logEventHandler(
       artist: body.artist,
       album: body.album ?? null,
       imageUrl: body.imageUrl ?? null,
+      serviceId: body.serviceId ?? null,
+      accountId: body.accountId ?? null,
       timestamp: body.timestamp,
     });
 

--- a/server/src/functions/log-event.ts
+++ b/server/src/functions/log-event.ts
@@ -1,0 +1,68 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { CosmosClient } from '@azure/cosmos';
+
+interface QueueEvent {
+  type: 'queued';
+  user: string;
+  uri: string;
+  trackName: string;
+  artist: string;
+  album?: string;
+  imageUrl?: string;
+  timestamp: number;
+}
+
+export async function logEventHandler(
+  request: HttpRequest,
+  context: InvocationContext,
+): Promise<HttpResponseInit> {
+  const connStr = process.env['COSMOS_CONNECTION_STRING'];
+  const dbName = process.env['COSMOS_DATABASE'] ?? 'truetunes';
+  const ctrName = process.env['COSMOS_CONTAINER'] ?? 'events';
+
+  if (!connStr) {
+    return { status: 500, jsonBody: { error: 'Cosmos not configured' } };
+  }
+
+  let body: QueueEvent;
+  try {
+    body = (await request.json()) as QueueEvent;
+  } catch {
+    return { status: 400, jsonBody: { error: 'Invalid JSON body' } };
+  }
+
+  if (!body?.user || !body?.uri || body?.type !== 'queued') {
+    return { status: 400, jsonBody: { error: 'Missing required fields' } };
+  }
+
+  try {
+    const client = new CosmosClient(connStr);
+    const container = client.database(dbName).container(ctrName);
+
+    const suffix = Math.random().toString(16).slice(2, 9);
+    const id = `${new Date(body.timestamp).toISOString()}::${suffix}`;
+
+    await container.items.create({
+      id,
+      userId: body.user,
+      uri: body.uri,
+      trackName: body.trackName,
+      artist: body.artist,
+      album: body.album ?? null,
+      imageUrl: body.imageUrl ?? null,
+      timestamp: body.timestamp,
+    });
+
+    context.log(`[log-event] ${id} user=${body.user} track=${body.trackName}`);
+    return { status: 201, jsonBody: { id }, headers: { 'Access-Control-Allow-Origin': '*' } };
+  } catch (err) {
+    context.error('[log-event] Cosmos write failed:', err);
+    return { status: 500, jsonBody: { error: String(err) } };
+  }
+}
+
+app.http('log-event', {
+  methods: ['POST'],
+  authLevel: 'anonymous',
+  handler: logEventHandler,
+});

--- a/server/src/functions/stats.ts
+++ b/server/src/functions/stats.ts
@@ -1,0 +1,96 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { CosmosClient } from '@azure/cosmos';
+
+type Period = 'today' | 'week' | 'alltime';
+
+function periodStartMs(period: Period): number {
+  if (period === 'today') {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+  }
+  if (period === 'week') return Date.now() - 7 * 24 * 60 * 60 * 1000;
+  return 0;
+}
+
+interface RawEvent {
+  userId: string;
+  trackName: string;
+  artist: string;
+  album?: string;
+  imageUrl?: string;
+}
+
+export async function statsHandler(
+  request: HttpRequest,
+  context: InvocationContext,
+): Promise<HttpResponseInit> {
+  const connStr = process.env['COSMOS_CONNECTION_STRING'];
+  const dbName = process.env['COSMOS_DATABASE'] ?? 'truetunes';
+  const ctrName = process.env['COSMOS_CONTAINER'] ?? 'events';
+
+  if (!connStr) {
+    return { status: 500, jsonBody: { error: 'Cosmos not configured' } };
+  }
+
+  const period = (request.query.get('period') ?? 'alltime') as Period;
+  const startMs = periodStartMs(period);
+
+  try {
+    const client = new CosmosClient(connStr);
+    const container = client.database(dbName).container(ctrName);
+
+    const query = startMs > 0
+      ? { query: 'SELECT c.userId, c.trackName, c.artist, c.album, c.imageUrl FROM c WHERE c.timestamp >= @start', parameters: [{ name: '@start', value: startMs }] }
+      : { query: 'SELECT c.userId, c.trackName, c.artist, c.album, c.imageUrl FROM c' };
+
+    const { resources } = await container.items
+      .query<RawEvent>(query, { enableCrossPartitionQuery: true })
+      .fetchAll();
+
+    // Aggregate in-process — fine at POC scale
+    const userCounts: Record<string, number> = {};
+    const trackMap: Record<string, { trackName: string; artist: string; album?: string; imageUrl?: string; count: number }> = {};
+    const artistCounts: Record<string, number> = {};
+
+    for (const e of resources) {
+      if (e.userId) userCounts[e.userId] = (userCounts[e.userId] ?? 0) + 1;
+      if (e.artist) artistCounts[e.artist] = (artistCounts[e.artist] ?? 0) + 1;
+      const key = `${e.trackName}||${e.artist}`;
+      if (!trackMap[key]) {
+        trackMap[key] = { trackName: e.trackName, artist: e.artist, album: e.album, imageUrl: e.imageUrl, count: 0 };
+      }
+      trackMap[key].count++;
+    }
+
+    const topUsers = Object.entries(userCounts)
+      .map(([userId, count]) => ({ userId, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    const topTracks = Object.values(trackMap)
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    const topArtists = Object.entries(artistCounts)
+      .map(([artist, count]) => ({ artist, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10);
+
+    context.log(`[stats] period=${period} events=${resources.length}`);
+
+    return {
+      jsonBody: { topUsers, topTracks, topArtists, totalEvents: resources.length, periodStart: startMs },
+      headers: { 'Access-Control-Allow-Origin': '*' },
+    };
+  } catch (err) {
+    context.error('[stats] query failed:', err);
+    return { status: 500, jsonBody: { error: String(err) } };
+  }
+}
+
+app.http('stats', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  handler: statsHandler,
+});

--- a/server/src/functions/stats.ts
+++ b/server/src/functions/stats.ts
@@ -19,6 +19,9 @@ interface RawEvent {
   artist: string;
   album?: string;
   imageUrl?: string;
+  uri?: string;
+  serviceId?: string;
+  accountId?: string;
 }
 
 export async function statsHandler(
@@ -41,16 +44,16 @@ export async function statsHandler(
     const container = client.database(dbName).container(ctrName);
 
     const query = startMs > 0
-      ? { query: 'SELECT c.userId, c.trackName, c.artist, c.album, c.imageUrl FROM c WHERE c.timestamp >= @start', parameters: [{ name: '@start', value: startMs }] }
-      : { query: 'SELECT c.userId, c.trackName, c.artist, c.album, c.imageUrl FROM c' };
+      ? { query: 'SELECT c.userId, c.trackName, c.artist, c.album, c.imageUrl, c.serviceId, c.accountId, c.uri FROM c WHERE c.timestamp >= @start', parameters: [{ name: '@start', value: startMs }] }
+      : { query: 'SELECT c.userId, c.trackName, c.artist, c.album, c.imageUrl, c.serviceId, c.accountId, c.uri FROM c' };
 
     const { resources } = await container.items
-      .query<RawEvent>(query, { enableCrossPartitionQuery: true })
+      .query<RawEvent>(query)
       .fetchAll();
 
     // Aggregate in-process — fine at POC scale
     const userCounts: Record<string, number> = {};
-    const trackMap: Record<string, { trackName: string; artist: string; album?: string; imageUrl?: string; count: number }> = {};
+    const trackMap: Record<string, { trackName: string; artist: string; album?: string; imageUrl?: string; uri?: string; serviceId?: string; accountId?: string; count: number }> = {};
     const artistCounts: Record<string, number> = {};
 
     for (const e of resources) {
@@ -58,7 +61,7 @@ export async function statsHandler(
       if (e.artist) artistCounts[e.artist] = (artistCounts[e.artist] ?? 0) + 1;
       const key = `${e.trackName}||${e.artist}`;
       if (!trackMap[key]) {
-        trackMap[key] = { trackName: e.trackName, artist: e.artist, album: e.album, imageUrl: e.imageUrl, count: 0 };
+        trackMap[key] = { trackName: e.trackName, artist: e.artist, album: e.album, imageUrl: e.imageUrl, uri: e.uri, serviceId: e.serviceId, accountId: e.accountId, count: 0 };
       }
       trackMap[key].count++;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1085,7 +1085,7 @@ ipcMain.handle('config:setDisplayName', async (_: IpcMainInvokeEvent, name: stri
 
 ipcMain.handle(
   'pubsub:publishQueued',
-  async (_: IpcMainInvokeEvent, item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string }) => {
+  async (_: IpcMainInvokeEvent, item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string; serviceId?: string; accountId?: string }) => {
     await officePubSub.publishQueued(item).catch(() => {
       /* silent */
     });
@@ -1099,6 +1099,8 @@ ipcMain.handle(
       artist: item.artist,
       album: item.album,
       imageUrl: item.imageUrl,
+      serviceId: item.serviceId,
+      accountId: item.accountId,
       timestamp: Date.now(),
     };
     broadcastToRenderers('attribution:event', event);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1085,7 +1085,7 @@ ipcMain.handle('config:setDisplayName', async (_: IpcMainInvokeEvent, name: stri
 
 ipcMain.handle(
   'pubsub:publishQueued',
-  async (_: IpcMainInvokeEvent, item: { uri: string; trackName: string; artist: string }) => {
+  async (_: IpcMainInvokeEvent, item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string }) => {
     await officePubSub.publishQueued(item).catch(() => {
       /* silent */
     });
@@ -1097,11 +1097,23 @@ ipcMain.handle(
       uri: item.uri,
       trackName: item.trackName,
       artist: item.artist,
+      album: item.album,
+      imageUrl: item.imageUrl,
       timestamp: Date.now(),
     };
     broadcastToRenderers('attribution:event', event);
   }
 );
+
+ipcMain.handle('stats:fetch', async (_: IpcMainInvokeEvent, period: string) => {
+  try {
+    const url = `${PUBSUB_FUNCTION_URL}/api/stats?period=${encodeURIComponent(period)}`;
+    const res = await fetch(url);
+    return await res.json();
+  } catch (err) {
+    return { error: String(err) };
+  }
+});
 
 ipcMain.handle('attribution:refresh', async () => {
   try {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -35,10 +35,11 @@ export interface SonosAPI {
   // Attribution / office presence
   getDisplayName: () => Promise<string | null>;
   setDisplayName: (name: string) => Promise<void>;
-  publishQueued: (item: { uri: string; trackName: string; artist: string }) => Promise<void>;
+  publishQueued: (item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string }) => Promise<void>;
   onAttributionMap: (cb: (map: AttributionMap) => void) => Unsubscribe;
   onAttributionEvent: (cb: (event: AttributionEvent) => void) => Unsubscribe;
   refreshAttribution: () => Promise<void>;
+  fetchStats: (period: string) => Promise<unknown>;
 }
 
 // Buffer early IPC events that may fire before React mounts and registers listeners.
@@ -126,6 +127,7 @@ contextBridge.exposeInMainWorld('sonos', {
     return () => ipcRenderer.removeListener('attribution:map', listener);
   },
   refreshAttribution: () => ipcRenderer.invoke('attribution:refresh'),
+  fetchStats: (period: string) => ipcRenderer.invoke('stats:fetch', period),
   onAttributionEvent: (cb: (event: AttributionEvent) => void): Unsubscribe => {
     const listener = (_e: unknown, event: AttributionEvent) => cb(event);
     ipcRenderer.on('attribution:event', listener);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -35,7 +35,7 @@ export interface SonosAPI {
   // Attribution / office presence
   getDisplayName: () => Promise<string | null>;
   setDisplayName: (name: string) => Promise<void>;
-  publishQueued: (item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string }) => Promise<void>;
+  publishQueued: (item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string; serviceId?: string; accountId?: string }) => Promise<void>;
   onAttributionMap: (cb: (map: AttributionMap) => void) => Unsubscribe;
   onAttributionEvent: (cb: (event: AttributionEvent) => void) => Unsubscribe;
   refreshAttribution: () => Promise<void>;

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -179,7 +179,7 @@ export class OfficePubSub {
   }
 
   /** Publish a "track queued" event and update blob storage. */
-  async publishQueued(item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string }): Promise<void> {
+  async publishQueued(item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string; serviceId?: string; accountId?: string }): Promise<void> {
     if (!item.uri) return;
 
     const event: AttributionEvent = {
@@ -190,6 +190,8 @@ export class OfficePubSub {
       artist: item.artist,
       album: item.album,
       imageUrl: item.imageUrl,
+      serviceId: item.serviceId,
+      accountId: item.accountId,
       timestamp: Date.now(),
     };
 

--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -69,6 +69,27 @@ function httpPut(rawUrl: string, body: string, headers: Record<string, string>):
   });
 }
 
+function httpPostJson(rawUrl: string, payload: unknown): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const buf = Buffer.from(JSON.stringify(payload), 'utf8');
+    const url = new URL(rawUrl);
+    const mod = url.protocol === 'https:' ? https : http;
+    const req = mod.request(
+      rawUrl,
+      { method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': buf.length } },
+      (res) => {
+        res.resume();
+        (res.statusCode ?? 0) >= 400
+          ? reject(new Error(`POST ${rawUrl} → ${res.statusCode}`))
+          : resolve();
+      },
+    );
+    req.on('error', reject);
+    req.write(buf);
+    req.end();
+  });
+}
+
 function httpPost(rawUrl: string): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     const url = new URL(rawUrl);
@@ -92,6 +113,7 @@ function httpPost(rawUrl: string): Promise<Buffer> {
 export class OfficePubSub {
   private ws: WebSocket | null = null;
   private blobSasUrl: string | null = null;
+  private functionUrl = '';
   private attributionMap: AttributionMap = {};
   private eventCbs: ((e: AttributionEvent) => void)[] = [];
   private username = '';
@@ -100,9 +122,10 @@ export class OfficePubSub {
   /** Connect to Azure Web PubSub and load blob history. Returns initial map. */
   async connect(username: string, functionUrl: string): Promise<AttributionMap> {
     this.username = username;
+    this.functionUrl = functionUrl.replace(/\/$/, '');
 
     // Get tokens from the Azure Function
-    const url = `${functionUrl.replace(/\/$/, '')}/api/connect?username=${encodeURIComponent(username)}`;
+    const url = `${this.functionUrl}/api/connect?username=${encodeURIComponent(username)}`;
     const raw = await httpPost(url);
     const { webPubSubUrl, blobSasUrl } = JSON.parse(raw.toString()) as {
       webPubSubUrl: string;
@@ -156,7 +179,7 @@ export class OfficePubSub {
   }
 
   /** Publish a "track queued" event and update blob storage. */
-  async publishQueued(item: { uri: string; trackName: string; artist: string }): Promise<void> {
+  async publishQueued(item: { uri: string; trackName: string; artist: string; album?: string; imageUrl?: string }): Promise<void> {
     if (!item.uri) return;
 
     const event: AttributionEvent = {
@@ -165,6 +188,8 @@ export class OfficePubSub {
       uri: item.uri,
       trackName: item.trackName,
       artist: item.artist,
+      album: item.album,
+      imageUrl: item.imageUrl,
       timestamp: Date.now(),
     };
 
@@ -191,6 +216,13 @@ export class OfficePubSub {
     this.saveAttribution().catch((err) => {
       console.warn('[pubsub] Blob write failed:', err.message);
     });
+
+    // Log to Cosmos via Azure Function (fire-and-forget)
+    if (this.functionUrl) {
+      httpPostJson(`${this.functionUrl}/api/log-event`, event).catch((err) => {
+        console.warn('[pubsub] Cosmos log failed:', err.message);
+      });
+    }
   }
 
   onEvent(cb: (e: AttributionEvent) => void): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ export interface AttributionEvent {
   artist: string;
   album?: string;
   imageUrl?: string;
+  serviceId?: string;
+  accountId?: string;
   timestamp: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export interface AttributionEvent {
   uri: string;
   trackName: string;
   artist: string;
+  album?: string;
+  imageUrl?: string;
   timestamp: number;
 }
 


### PR DESCRIPTION
## Summary

- **Cosmos DB event logging**: Every queue-add writes to truetunes-cosmos (events container, partition /userId, 90-day TTL) capturing userId, uri, trackName, artist, album, imageUrl, serviceId, accountId, timestamp.
- **New Azure Function log-event**: POST /api/log-event - writes queue events to Cosmos.
- **New Azure Function stats**: GET /api/stats?period=today|week|alltime - aggregates top queuers, tracks, artists.
- **ARM template updated**: Provisions truetunes-cosmos, wires COSMOS_* env vars into Function App. Already deployed to truetunes-rg.
- **Leaderboard tab**: New /leaderboard route - ranked user bar chart, top tracks (draggable onto queue), top artists/albums (clickable to search results).
- Attribution event extended with album, imageUrl, serviceId, accountId threaded from renderer through IPC to Cosmos.

## Reviewer notes

- Deploy server functions after merging: cd server && npm run build && func azure functionapp publish truetunes-fn
- Old Cosmos events without uri/serviceId/accountId still support drag-to-queue via main process config fallback.
- Blob attribution flow unchanged - late-joiner hydration unaffected.

## Test plan

- [ ] Queue a track ? document appears in Cosmos Data Explorer with correct fields
- [ ] Leaderboard tab loads, period selector and refresh work
- [ ] Drag a top track onto the queue sidebar ? track added
- [ ] Click artist name ? navigates to search results
- [ ] Click album name ? navigates to search results
- [ ] Reconnect client ? late-joiner blob attribution still works

Generated with [Claude Code](https://claude.com/claude-code)