### PR TITLE
F2 feedback dialog, auto-update, queue improvements

### DIFF
--- a/renderer/src/components/queue/QueueSidebar.tsx
+++ b/renderer/src/components/queue/QueueSidebar.tsx
@@ -32,7 +32,18 @@ export function QueueSidebar(
   const lastSelected = useRef<number | null>(null);
   const draggingSet  = useRef<Set<number>>(new Set());
 
+  function scrollToNowPlaying() {
+    contentRef.current?.querySelector<HTMLElement>('[data-playing="true"]')
+      ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }
+
   useEffect(() => { setSelected(new Set()); }, [open, items]);
+
+  useEffect(() => {
+    if (!open) return;
+    const id = setTimeout(scrollToNowPlaying, 50);
+    return () => clearTimeout(id);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -169,6 +180,7 @@ export function QueueSidebar(
         ) : (
           <div className={styles.headerActions}>
             <button className={styles.iconBtn} onClick={onRefresh} title="Refresh">↺</button>
+            <button className={styles.iconBtn} onClick={scrollToNowPlaying} title="Jump to now playing">⊙</button>
             {items.length > 0 && (
               <button className={styles.iconBtn} title="Clear queue" onClick={() => setPendingClear(true)}>⊘</button>
             )}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, safeStorage, session, Menu, IpcMainInvokeEvent } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, safeStorage, session, Menu, IpcMainInvokeEvent } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { officePubSub } from './pubsub';
 import * as path from 'path';
@@ -1484,11 +1484,26 @@ function buildMenu(): void {
 }
 
 if (app.isPackaged) {
-  autoUpdater.checkForUpdatesAndNotify();
-  // autoUpdater.on('update-downloaded', () => {
-  //   BrowserWindow.getAllWindows().forEach((w) => w.destroy());
-  //   autoUpdater.quitAndInstall(true, false);
-  // });
+  autoUpdater.autoDownload = true;
+
+  const pollInterval = setInterval(() => autoUpdater.checkForUpdates(), 15 * 60 * 1000);
+  autoUpdater.checkForUpdates();
+
+  autoUpdater.once('update-available', () => clearInterval(pollInterval));
+
+  autoUpdater.once('update-downloaded', ({ version }) => {
+    dialog.showMessageBox({
+      type: 'info',
+      title: 'Update ready — True Tunes',
+      message: `Version ${version} has been downloaded and is ready to install.`,
+      detail: 'Restart now to apply the update, or continue and it will install on next launch.',
+      buttons: ['Restart now', 'Later'],
+      defaultId: 0,
+      cancelId: 1,
+    }).then(({ response }: { response: number }) => {
+      if (response === 0) autoUpdater.quitAndInstall(true, true);
+    });
+  });
 }
 
 // ─── Process-level error handlers ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **F2 feedback dialog** — press F2 to open a bug report / feature request form that creates a GitHub issue directly on TrueNorthIT/TrueTunes via a baked-in PAT (`VITE_GITHUB_PAT`). Type toggle (Bug / Feature Request), title, description, success state with link to created issue.
- **Auto-update** — polls for updates every 15 minutes, stops polling once an update is found, downloads in the background, then shows an Electron dialog (not an OS notification) prompting restart.
- **GitHub releases** — `releaseType` set to `release` so CI publishes directly rather than drafts. `VITE_GITHUB_PAT` secret added to publish workflow.
- **Jump to now playing** — ⊙ button in queue header scrolls to the current track. Queue also auto-scrolls to now playing when opened.

## Test plan

- [x] Press F2, submit a bug and a feature request — check issues appear on GitHub with correct labels
- [x] Verify `VITE_GITHUB_PAT` is set in `renderer/.env` locally and as a GitHub secret for CI builds
- [x] Confirm CI publish job produces a public release (not draft) on merge to main
- [x] Open queue mid-playlist — confirm it scrolls to the playing track automatically
- [x] Click ⊙ button — confirm it scrolls to now playing

🤖 Generated with [Claude Code](https://claude.com/claude-code)