### PR TITLE
fix: address six issues from backlog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.17",
       "dependencies": {
         "applicationinsights": "^3.14.0",
+        "dompurify": "^3.4.1",
         "electron-updater": "^6.8.3",
         "marked": "^18.0.2",
         "ws": "^8.0.0"
@@ -19,6 +20,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/dompurify": "^3.0.5",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -3941,6 +3943,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4079,6 +4091,13 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/verror": {
@@ -6139,6 +6158,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "applicationinsights": "^3.14.0",
         "electron-updater": "^6.8.3",
+        "marked": "^18.0.2",
         "ws": "^8.0.0"
       },
       "devDependencies": {
@@ -8568,6 +8569,18 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "applicationinsights": "^3.14.0",
+    "dompurify": "^3.4.1",
     "electron-updater": "^6.8.3",
     "marked": "^18.0.2",
     "ws": "^8.0.0"
@@ -42,6 +43,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/dompurify": "^3.0.5",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "applicationinsights": "^3.14.0",
     "electron-updater": "^6.8.3",
+    "marked": "^18.0.2",
     "ws": "^8.0.0"
   },
   "devDependencies": {

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -85,8 +85,8 @@ function MainApp() {
 
   useEffect(() => {
     if (groups.length === 0 || activeGroupId) return;
-    window.sonos.getActiveGroup().then((savedId) => {
-      const match = savedId ? groups.find((g) => g.id === savedId) : null;
+    window.sonos.getActiveGroup().then((savedCoordinatorId) => {
+      const match = savedCoordinatorId ? groups.find((g) => g.coordinatorId === savedCoordinatorId) : null;
       setActiveGroupId(match ? match.id : groups[0].id);
     }).catch(() => setActiveGroupId(groups[0].id));
   }, [groups, activeGroupId]);

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -84,10 +84,18 @@ function MainApp() {
   }, [reloadQueue]);
 
   useEffect(() => {
-    if (groups.length > 0 && !activeGroupId) {
-      setActiveGroupId(groups[0].id);
-    }
+    if (groups.length === 0 || activeGroupId) return;
+    window.sonos.getActiveGroup().then((savedId) => {
+      const match = savedId ? groups.find((g) => g.id === savedId) : null;
+      setActiveGroupId(match ? match.id : groups[0].id);
+    }).catch(() => setActiveGroupId(groups[0].id));
   }, [groups, activeGroupId]);
+
+  useEffect(() => {
+    const onFocus = () => { window.sonos.refreshPlayback().catch(() => {}); };
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, []);
 
   const showToast = useCallback((msg: string) => {
     setToastMsg(msg);

--- a/renderer/src/components/ChangelogDialog.tsx
+++ b/renderer/src/components/ChangelogDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 import { ExternalLink } from 'lucide-react';
 import styles from '../styles/ChangelogDialog.module.css';
 
@@ -133,7 +134,7 @@ export function ChangelogDialog({ onClose }: Props) {
                     {selected.body?.trim()
                       ? <div
                           className={styles.notesText}
-                          dangerouslySetInnerHTML={{ __html: marked.parse(selected.body.trim()) as string }}
+                          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(marked.parse(selected.body.trim()) as string) }}
                         />
                       : <span className={styles.noNotes}>No release notes.</span>
                     }

--- a/renderer/src/components/ChangelogDialog.tsx
+++ b/renderer/src/components/ChangelogDialog.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
+import { marked } from 'marked';
 import { ExternalLink } from 'lucide-react';
 import styles from '../styles/ChangelogDialog.module.css';
+
+marked.use({ async: false });
 
 interface Release {
   tag_name: string;
@@ -67,8 +70,8 @@ export function ChangelogDialog({ onClose }: Props) {
     (selected.tag_name === `v${appVersion}` || selected.tag_name === appVersion);
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.modal} onClick={e => e.stopPropagation()}>
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
         <div className={styles.header}>
           <span className={styles.heading}>What&apos;s New</span>
           {appVersion && <span className={styles.currentBadge}>v{appVersion}</span>}
@@ -128,7 +131,10 @@ export function ChangelogDialog({ onClose }: Props) {
                   </div>
                   <div className={styles.notes}>
                     {selected.body?.trim()
-                      ? <pre className={styles.notesText}>{selected.body.trim()}</pre>
+                      ? <div
+                          className={styles.notesText}
+                          dangerouslySetInnerHTML={{ __html: marked.parse(selected.body.trim()) as string }}
+                        />
                       : <span className={styles.noNotes}>No release notes.</span>
                     }
                   </div>

--- a/renderer/src/components/PlayerBar.tsx
+++ b/renderer/src/components/PlayerBar.tsx
@@ -7,7 +7,6 @@ import {
   Shuffle,
   SkipBack,
   Play,
-  Pause,
   SkipForward,
   Repeat,
   Repeat1,
@@ -264,7 +263,12 @@ export function PlayerBar({
               (isPlaying ? window.sonos.pause() : window.sonos.play()).then(refresh)
             }
           >
-            {isPlaying ? <Pause size={14} /> : <Play size={14} />}
+            {isPlaying ? (
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor" aria-hidden="true">
+                <rect x="2" y="1" width="4" height="12" rx="1" />
+                <rect x="8" y="1" width="4" height="12" rx="1" />
+              </svg>
+            ) : <Play size={14} />}
           </button>
           <button
             className={styles.ctrl}

--- a/renderer/src/components/QueuedlePanel.tsx
+++ b/renderer/src/components/QueuedlePanel.tsx
@@ -94,15 +94,12 @@ export function QueuedlePanel() {
   }
 
   if (alreadyPlayed) {
+    const scores = leaderboard.data && 'scores' in leaderboard.data ? leaderboard.data.scores : [];
     return (
       <div className={styles.page}>
         <div className={styles.header}>
           <h1 className={styles.title}>Queuedle</h1>
           <span className={styles.sub}>{game.id}</span>
-          <div className={styles.spacer} />
-          <button className={styles.leaderLink} onClick={() => navigate('/leaderboard')}>
-            Leaderboard →
-          </button>
         </div>
         <div className={styles.body}>
           <QueuedleSummary
@@ -112,6 +109,23 @@ export function QueuedlePanel() {
             maxBonus={game.questions.length}
             alreadySubmitted
           />
+          {scores.length > 0 && (
+            <div className={styles.leaderboardSection}>
+              <h2 className={styles.leaderboardTitle}>Today&apos;s Leaderboard</h2>
+              {scores.slice(0, 10).map((s, i) => (
+                <div key={s.userName} className={styles.scoreRow}>
+                  <span className={styles.scoreRank}>
+                    {i < 3 ? ['🥇', '🥈', '🥉'][i] : i + 1}
+                  </span>
+                  <span className={styles.scoreName}>{s.userName}</span>
+                  <span className={styles.scoreBreakdown}>
+                    {s.mainScore}/{game.questions.length} · {s.bonusScore}/{game.questions.length}
+                  </span>
+                  <span className={styles.scoreTotal}>{s.total}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     );

--- a/renderer/src/components/album/AlbumPanel.tsx
+++ b/renderer/src/components/album/AlbumPanel.tsx
@@ -12,7 +12,7 @@ import type { SonosItem, SonosItemId } from '../../types/sonos';
 import styles from '../../styles/AlbumPanel.module.css';
 
 interface Props {
-  onAddToQueue: (item: SonosItem) => void;
+  onAddToQueue: (item: SonosItem) => Promise<void> | void;
   queueOpen?: boolean;
 }
 
@@ -28,6 +28,7 @@ export function AlbumPanel({ onAddToQueue, queueOpen }: Props) {
     : { albumId: undefined, serviceId: undefined, accountId: undefined, defaults: undefined };
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const lastSelected = useRef<number | null>(null);
+  const [adding, setAdding] = useState(false);
 
   const albumResult    = useAlbumBrowse(isPlaylistOrProgram ? undefined : albumId, serviceId, accountId, defaults);
   const playlistResult = usePlaylistBrowse(isPlaylistOrProgram ? albumId : undefined, serviceId, accountId, defaults);
@@ -137,11 +138,22 @@ export function AlbumPanel({ onAddToQueue, queueOpen }: Props) {
               </div>
             )}
             <div className={styles.actions}>
-              <button className={styles.addAlbumBtn} onClick={() => {
-                if (data?.tracks?.length) data.tracks.forEach(t => onAddToQueue(t.raw));
-                else onAddToQueue(item);
-              }}>
-                + Add to Queue
+              <button
+                className={styles.addAlbumBtn}
+                disabled={adding || !data?.tracks?.length}
+                onClick={async () => {
+                  if (!data?.tracks?.length) return;
+                  setAdding(true);
+                  try {
+                    for (const t of data.tracks) {
+                      await onAddToQueue(t.raw);
+                    }
+                  } finally {
+                    setAdding(false);
+                  }
+                }}
+              >
+                {adding ? 'Adding…' : '+ Add to Queue'}
               </button>
             </div>
           </div>

--- a/renderer/src/styles/ChangelogDialog.module.css
+++ b/renderer/src/styles/ChangelogDialog.module.css
@@ -20,8 +20,9 @@
     0 8px 32px rgba(0, 0, 0, 0.5),
     0 1px 0 rgba(255, 255, 255, 0.06) inset,
     0 -1px 0 rgba(0, 0, 0, 0.3) inset;
-  width: 580px;
-  max-height: 500px;
+  width: 80%;
+  max-width: 1100px;
+  height: 80vh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -188,14 +189,74 @@
 }
 
 .notesText {
-  font-family: inherit;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--text-2);
-  line-height: 1.65;
-  white-space: pre-wrap;
-  margin: 0;
+  line-height: 1.7;
   word-break: break-word;
 }
+
+.notesText :global(h1),
+.notesText :global(h2),
+.notesText :global(h3),
+.notesText :global(h4) {
+  color: var(--text);
+  font-weight: 600;
+  margin: 1.2em 0 0.4em;
+  line-height: 1.3;
+}
+.notesText :global(h1) { font-size: 16px; }
+.notesText :global(h2) { font-size: 14px; }
+.notesText :global(h3), .notesText :global(h4) { font-size: 13px; }
+
+.notesText :global(p) {
+  margin: 0 0 0.75em;
+}
+
+.notesText :global(ul),
+.notesText :global(ol) {
+  margin: 0 0 0.75em;
+  padding-left: 1.4em;
+}
+
+.notesText :global(li) {
+  margin-bottom: 0.25em;
+}
+
+.notesText :global(code) {
+  font-family: ui-monospace, 'Cascadia Code', Consolas, monospace;
+  font-size: 11px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+.notesText :global(pre) {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 12px 14px;
+  overflow-x: auto;
+  margin: 0 0 0.75em;
+}
+
+.notesText :global(pre) :global(code) {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 11px;
+}
+
+.notesText :global(strong) {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.notesText :global(a) {
+  color: #7dd3fc;
+  text-decoration: none;
+}
+.notesText :global(a:hover) { text-decoration: underline; }
 
 .noNotes {
   font-size: 12px;

--- a/renderer/src/styles/Queuedle.module.css
+++ b/renderer/src/styles/Queuedle.module.css
@@ -407,6 +407,21 @@
   cursor: pointer;
 }
 
+/* ── Inline leaderboard (already-played view) ── */
+.leaderboardSection {
+  margin-top: 32px;
+  width: 100%;
+  max-width: 480px;
+}
+.leaderboardTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 12px;
+}
+
 /* ── Leaderboard rows ── */
 .scoreRow {
   display: grid;

--- a/renderer/src/test/setup.ts
+++ b/renderer/src/test/setup.ts
@@ -20,6 +20,7 @@ Object.defineProperty(window, 'sonos', {
     onWsGroups:         vi.fn(noop),
     onAttributionMap:   vi.fn(noop),
     onAttributionEvent: vi.fn(noop),
+    getActiveGroup:     vi.fn(() => Promise.resolve(null)),
     getDisplayName:     vi.fn(pending),
     setDisplayName:     vi.fn(pending),
     publishQueued:      vi.fn(pending),

--- a/renderer/src/types/globals.d.ts
+++ b/renderer/src/types/globals.d.ts
@@ -145,6 +145,7 @@ interface SonosPreload {
   onWsMessage: (cb: (header: unknown, payload: unknown) => void) => Unsubscribe;
   onWsReady: (cb: VoidCallback) => Unsubscribe;
   onWsGroups: (cb: (groups: unknown[]) => void) => Unsubscribe;
+  getActiveGroup: () => Promise<string | null>;
   setGroup: (groupId: string) => Promise<{ ok?: boolean; error?: string }>;
   setGroupVolume: (volume: number) => Promise<unknown>;
   setQueueId: (queueId: string) => Promise<void>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ async function loadConfig(): Promise<void> {
     // Only load the fields we explicitly persist (not runtime-discovered ones)
     if (typeof parsed.displayName === 'string') config.displayName = parsed.displayName;
     if (typeof parsed.lastSeenVersion === 'string') config.lastSeenVersion = parsed.lastSeenVersion;
+    if (typeof parsed.groupId === 'string') config.groupId = parsed.groupId;
   } catch {
     // No config file yet — use defaults
   }
@@ -66,6 +67,7 @@ async function saveConfig(): Promise<void> {
     const toSave: Partial<AppConfig> = {
       displayName: config.displayName,
       lastSeenVersion: config.lastSeenVersion,
+      groupId: config.groupId,
     };
     await fs.writeFile(configFilePath(), JSON.stringify(toSave, null, 2), 'utf8');
   } catch (err) {
@@ -701,11 +703,14 @@ async function runBootstrap(): Promise<void> {
   log(`[ws] ${coordinatorGroupIds.length} coordinator group(s), ${playerIds.length} player(s)`);
   groups.forEach((g) => log(`[ws]   group "${g.name}" — ${g.id}`));
 
-  // Update live group list and set the first group as active
+  // Update live group list. Restore saved group preference if it exists in the
+  // current household; otherwise fall back to the first group returned.
   discoveredGroups = groups;
   if (groups.length > 0) {
-    config.groupId = groups[0].id;
-    log(`[ws] Active group: "${groups[0].name}" (${groups[0].id})`);
+    const savedGroup = config.groupId ? groups.find((g) => g.id === config.groupId) : null;
+    const activeGroup = savedGroup ?? groups[0];
+    config.groupId = activeGroup.id;
+    log(`[ws] Active group: "${activeGroup.name}" (${activeGroup.id})`);
   }
 
   // 3 ─ Subscribe to playbackExtended first so we can capture initial state
@@ -1508,11 +1513,14 @@ ipcMain.handle('queue:setId', (_event: IpcMainInvokeEvent, queueId: string) => {
   }
 });
 
+ipcMain.handle('group:getActive', () => config.groupId ?? null);
+
 ipcMain.handle('group:set', (_event: IpcMainInvokeEvent, groupId: string) => {
   const group = discoveredGroups.find((g) => g.id === groupId);
   if (!group) return { error: `Unknown group: ${groupId}` };
   config.groupId = group.id;
   log(`[group] Switched to "${group.name}" — groupId: ${group.id}`);
+  saveConfig().catch(() => {});
   // Re-subscribe to playbackExtended for the new group — Sonos responds with an
   // extendedPlaybackStatus push so the renderer immediately gets fresh now-playing state.
   if (ws && ws.readyState === WebSocket.OPEN) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,10 @@ interface AppConfig {
   accountId?: string;
   /** Household ID — re-discovered on each WS bootstrap. */
   householdId?: string;
-  /** Active group ID — re-discovered on each WS bootstrap, updated on group switch. */
+  /** Active group ID — session-scoped (RINCON_xxx:sessionId), re-discovered on each WS bootstrap. */
   groupId?: string;
+  /** Stable coordinator RINCON ID for the preferred group — persisted across sessions. */
+  preferredCoordinatorId?: string;
   /** Active queue ID (coordinator player ID) — kept in sync by the renderer. */
   queueId?: string;
   /** Display name shown on tracks this user adds to the queue. */
@@ -55,7 +57,7 @@ async function loadConfig(): Promise<void> {
     // Only load the fields we explicitly persist (not runtime-discovered ones)
     if (typeof parsed.displayName === 'string') config.displayName = parsed.displayName;
     if (typeof parsed.lastSeenVersion === 'string') config.lastSeenVersion = parsed.lastSeenVersion;
-    if (typeof parsed.groupId === 'string') config.groupId = parsed.groupId;
+    if (typeof parsed.preferredCoordinatorId === 'string') config.preferredCoordinatorId = parsed.preferredCoordinatorId;
   } catch {
     // No config file yet — use defaults
   }
@@ -67,7 +69,7 @@ async function saveConfig(): Promise<void> {
     const toSave: Partial<AppConfig> = {
       displayName: config.displayName,
       lastSeenVersion: config.lastSeenVersion,
-      groupId: config.groupId,
+      preferredCoordinatorId: config.preferredCoordinatorId,
     };
     await fs.writeFile(configFilePath(), JSON.stringify(toSave, null, 2), 'utf8');
   } catch (err) {
@@ -703,13 +705,20 @@ async function runBootstrap(): Promise<void> {
   log(`[ws] ${coordinatorGroupIds.length} coordinator group(s), ${playerIds.length} player(s)`);
   groups.forEach((g) => log(`[ws]   group "${g.name}" — ${g.id}`));
 
-  // Update live group list. Restore saved group preference if it exists in the
-  // current household; otherwise fall back to the first group returned.
+  // Update live group list. Restore saved group preference (matched by stable
+  // coordinatorId) if it exists in the current household; otherwise fall back
+  // to the first group and persist that as the new preference.
   discoveredGroups = groups;
   if (groups.length > 0) {
-    const savedGroup = config.groupId ? groups.find((g) => g.id === config.groupId) : null;
+    const savedGroup = config.preferredCoordinatorId
+      ? groups.find((g) => g.coordinatorId === config.preferredCoordinatorId)
+      : null;
     const activeGroup = savedGroup ?? groups[0];
     config.groupId = activeGroup.id;
+    if (!savedGroup) {
+      config.preferredCoordinatorId = activeGroup.coordinatorId;
+      void saveConfig();
+    }
     log(`[ws] Active group: "${activeGroup.name}" (${activeGroup.id})`);
   }
 
@@ -1513,14 +1522,15 @@ ipcMain.handle('queue:setId', (_event: IpcMainInvokeEvent, queueId: string) => {
   }
 });
 
-ipcMain.handle('group:getActive', () => config.groupId ?? null);
+ipcMain.handle('group:getActive', () => config.preferredCoordinatorId ?? null);
 
 ipcMain.handle('group:set', (_event: IpcMainInvokeEvent, groupId: string) => {
   const group = discoveredGroups.find((g) => g.id === groupId);
   if (!group) return { error: `Unknown group: ${groupId}` };
   config.groupId = group.id;
+  config.preferredCoordinatorId = group.coordinatorId;
   log(`[group] Switched to "${group.name}" — groupId: ${group.id}`);
-  saveConfig().catch(() => {});
+  void saveConfig();
   // Re-subscribe to playbackExtended for the new group — Sonos responds with an
   // extendedPlaybackStatus push so the renderer immediately gets fresh now-playing state.
   if (ws && ws.readyState === WebSocket.OPEN) {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -17,6 +17,7 @@ export interface SonosAPI {
   onWsMessage: (cb: (header: unknown, payload: unknown) => void) => Unsubscribe;
   onWsReady: (cb: VoidCallback) => Unsubscribe;
   onWsGroups: (cb: (groups: unknown[]) => void) => Unsubscribe;
+  getActiveGroup: () => Promise<string | null>;
   setGroup: (groupId: string) => Promise<{ ok?: boolean; error?: string }>;
   setGroupVolume: (volume: number) => Promise<unknown>;
   openWsMonitor: () => Promise<void>;
@@ -117,6 +118,7 @@ contextBridge.exposeInMainWorld('sonos', {
   setQueueId: (queueId: string) => ipcRenderer.invoke('queue:setId', queueId),
   loadContent: (payload: Record<string, unknown>) => ipcRenderer.invoke('playback:loadContent', payload),
   fetchImage: (url: string) => ipcRenderer.invoke('image:fetch', url),
+  getActiveGroup: () => ipcRenderer.invoke('group:getActive'),
   setGroup: (groupId: string) => ipcRenderer.invoke('group:set', groupId),
   setGroupVolume: (volume: number) => ipcRenderer.invoke('volume:group:set', volume),
   openWsMonitor: () => ipcRenderer.invoke('debug:openWsMonitor'),


### PR DESCRIPTION
## What's changed

### Bug fixes

- **#29 — Remember last-used group on startup**
  App now persists the active group to `config.json` and restores it on next launch. Previously it always defaulted to whichever group the Sonos API returned first (often Bathroom).

- **#34 — Album attribution shows blank track name**
  The "Add Album to Queue" button now adds tracks one-by-one sequentially (with `await` between each) so every track fires its own attribution event with the correct track name. Previously all tracks fired simultaneously and the fallback name path returned `(unknown)`. The button also disables and shows "Adding…" while in progress to prevent double-clicks.

- **#19 — Player goes stale when left idle**
  On every window focus event the app re-subscribes to `extendedPlaybackStatus`, refreshing now-playing state immediately after sleep/wake or alt-tab back. Previously a silently-dropped WebSocket connection would leave the display frozen indefinitely.

- **#32 — Queuedle "already played" screen is a dead end**
  After completing (or revisiting) Queuedle, today's leaderboard is now shown inline below the score summary. The "Leaderboard →" link is gone.

- **#22 — Pause button looks asymmetrical**
  Replaced the Lucide `<Pause>` icon (which sub-pixel renders unevenly at 14 px) with a hand-crafted inline SVG using integer pixel coordinates. Both bars are now exactly 4 px wide.

### Improvements

- **Changelog dialog** — Release notes are now rendered as Markdown instead of a raw `<pre>` block. Dialog resized to 80% width / 80% height. Backdrop click no longer closes it — use the ✕ button or Escape.