### PR TITLE
feat(lyrics): time-synced lyrics panel with Genius descriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,8 @@ VITE_GITHUB_PAT=
 # Read by `server/scripts/deploy.mjs` and passed to ARM as the `vestaboardApiKey` parameter.
 # Leave blank to disable Vestaboard messages.
 VESTABOARD_API_KEY=
+
+# Genius API access token for song descriptions in the lyrics panel.
+# Get one at https://genius.com/api-clients — create a client, copy the Client Access Token.
+# Leave blank to disable Genius descriptions.
+GENIUS_ACCESS_TOKEN=

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -39,6 +39,8 @@ import { MiniPlayerShell } from './components/MiniPlayer';
 import { DisplayNameModal } from './components/DisplayNameModal';
 import { FeedbackDialog } from './components/FeedbackDialog';
 import { ChangelogDialog } from './components/ChangelogDialog';
+import { LyricsPanel } from './components/LyricsPanel';
+import { usePrefetchNextLyrics } from './hooks/usePrefetchNextLyrics';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Splash } from './components/Splash';
 import { getName } from './lib/itemHelpers';
@@ -67,6 +69,7 @@ function MainApp() {
                                                       (etag) => { queueVersionRef.current = etag; },
                                                       (msg) => showToast(`Queue refresh failed: ${msg}`));
   const { restore: runRestore } = useRestoreQueueAction();
+  usePrefetchNextLyrics(queueItems, playback.queueItemId);
 
   const reloadQueue = useCallback(() => {
     reloadQueueRaw();
@@ -472,6 +475,7 @@ function MainApp() {
           <Route path="/container/:id" element={<ContainerPanel onAddToQueue={handleAddToQueue} />} />
           <Route path="/leaderboard" element={<LeaderboardPanel />} />
           <Route path="/queuedle" element={<QueuedlePanel />} />
+          <Route path="/lyrics" element={<LyricsPanel playback={playback} />} />
         </Routes>
       </div>
       <QueueSidebar

--- a/renderer/src/components/LyricsPanel.module.css
+++ b/renderer/src/components/LyricsPanel.module.css
@@ -1,0 +1,272 @@
+/* ── Full-screen overlay ── */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 149;
+  background: #06060e;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: panelIn 0.35s ease;
+  isolation: isolate;
+  will-change: transform;
+}
+
+@keyframes panelIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Background layers ── */
+.bgArt {
+  position: absolute;
+  inset: -8%;
+  width: 116%;
+  height: 116%;
+  object-fit: cover;
+  filter: blur(72px) saturate(1.35) brightness(0.32);
+  pointer-events: none;
+}
+
+.waveBg {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    160deg,
+    rgba(var(--dc, 90, 70, 180), 0.65) 0%,
+    rgba(var(--dc, 90, 70, 180), 0.35) 45%,
+    rgba(var(--dc, 90, 70, 180), 0.12) 75%,
+    rgba(4, 4, 14, 0.9) 100%
+  );
+  pointer-events: none;
+}
+
+.vignette {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 50% 45%, transparent 20%, rgba(0, 0, 0, 0.52) 100%);
+  pointer-events: none;
+}
+
+/* ── Close button ── */
+.closeBtn {
+  position: absolute;
+  top: 22px;
+  right: 24px;
+  z-index: 20;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.75);
+  border-radius: 50%;
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.closeBtn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+/* ── Two-column content area ── */
+.content {
+  position: relative;
+  z-index: 5;
+  flex: 1;
+  display: grid;
+  grid-template-columns: 38% 62%;
+  min-height: 0;
+}
+
+/* ── Left panel ── */
+.leftPanel {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 110px 44px 140px 60px;
+  gap: 20px;
+  overflow: hidden;
+  max-width: 560px;
+}
+
+.bigArt {
+  width: min(260px, 75%);
+  aspect-ratio: 1;
+  border-radius: 18px;
+  object-fit: cover;
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.7),
+    0 0 0 1px rgba(255, 255, 255, 0.06);
+  flex-shrink: 0;
+}
+
+.bigArtPh {
+  width: min(260px, 75%);
+  aspect-ratio: 1;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.07);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.25);
+  flex-shrink: 0;
+}
+
+.meta {
+  text-align: left;
+  width: 100%;
+}
+
+.metaTrack {
+  font-size: 36px;
+  font-weight: 700;
+  color: rgba(var(--tc, 255, 255, 255), 1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.metaArtist {
+  font-size: 22px;
+  color: rgba(var(--tc, 255, 255, 255), 0.65);
+  margin-top: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.geniusDesc {
+  font-size: 20px;
+  line-height: 1.7;
+  color: rgba(var(--tc, 255, 255, 255), 0.5);
+  text-align: left;
+  width: 100%;
+  flex: 1;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.geniusDesc::-webkit-scrollbar {
+  display: none;
+}
+
+.descPara {
+  margin: 0 0 10px;
+}
+
+.descPara:last-child {
+  margin-bottom: 0;
+}
+
+.descLink {
+  color: rgba(var(--tc, 255, 255, 255), 0.75);
+  cursor: pointer;
+}
+
+.descLink:hover {
+  color: rgba(var(--tc, 255, 255, 255), 1);
+}
+
+/* ── Right panel — lyrics ── */
+.lyricsContainer {
+  position: relative;
+  overflow-y: auto;
+  scrollbar-width: none;
+  padding-bottom: 120px;
+}
+
+.lyricsContainer::-webkit-scrollbar {
+  display: none;
+}
+
+.lyricsPad {
+  padding: 34vh 8% 34vh 4%;
+  text-align: left;
+}
+
+.line {
+  padding: 9px 0;
+  font-size: 22px;
+  font-weight: 400;
+  color: #fff;
+  line-height: 1.4;
+  cursor: default;
+  transition: opacity 0.55s ease, font-size 0.45s ease;
+}
+
+.lineActive {
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.status {
+  font-size: 20px;
+  color: rgba(255, 255, 255, 0.38);
+  padding: 20px 0;
+}
+
+/* ── Lyrics loading state ── */
+.loadingWrap {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding-bottom: 120px; /* nudge up to match where active lyric sits */
+}
+
+.loadingIcon {
+  color: rgba(255, 255, 255, 0.7);
+  animation: breathe 2.2s ease-in-out infinite;
+  line-height: 1;
+}
+
+.loadingLabel {
+  font-size: 18px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.55);
+  letter-spacing: 0.01em;
+}
+
+.dots {
+  display: flex;
+  gap: 6px;
+}
+
+.dots span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.35);
+  animation: dot 1.2s ease-in-out infinite;
+}
+
+.dots span:nth-child(2) { animation-delay: 0.2s; }
+.dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes breathe {
+  0%, 100% { opacity: 0.45; transform: scale(0.96); }
+  50%       { opacity: 1;    transform: scale(1.04); }
+}
+
+@keyframes dot {
+  0%, 80%, 100% { opacity: 0.25; transform: translateY(0); }
+  40%           { opacity: 1;    transform: translateY(-4px); }
+}
+
+@media (max-width: 800px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+
+  .leftPanel {
+    display: none;
+  }
+}

--- a/renderer/src/components/LyricsPanel.tsx
+++ b/renderer/src/components/LyricsPanel.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { X, Music2, Mic } from 'lucide-react';
+import { useNowPlaying } from '../hooks/useNowPlaying';
+import { useLyrics } from '../hooks/useLyrics';
+import { useGeniusDescription } from '../hooks/useGeniusDescription';
+import type { PlaybackState } from '../hooks/usePlayback';
+import styles from './LyricsPanel.module.css';
+import type React from 'react';
+
+interface Props {
+  playback: PlaybackState;
+}
+
+function renderDom(node: GeniusDomNode, key: number | string): React.ReactNode {
+  if (typeof node === 'string') return node;
+  const children = node.children?.map((c, i) => renderDom(c, i)) ?? null;
+  switch (node.tag) {
+    case 'root':   return <>{children}</>;
+    case 'p':      return <p key={key} className={styles.descPara}>{children}</p>;
+    case 'em':     return <em key={key}>{children}</em>;
+    case 'strong': return <strong key={key}>{children}</strong>;
+    case 'a':      return <span key={key} className={styles.descLink} onClick={() => { const href = node.attributes?.href; if (href) window.sonos.openExternal(href); }}>{children}</span>;
+    case 'br':     return <br key={key} />;
+    default:       return <span key={key}>{children}</span>;
+  }
+}
+
+function textColor(dominantColor: string | null): string {
+  if (!dominantColor) return '255, 255, 255';
+  const [r, g, b] = dominantColor.split(',').map(Number);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 145 ? '0, 0, 0' : '255, 255, 255';
+}
+
+export function LyricsPanel({ playback }: Props) {
+  const navigate = useNavigate();
+  const onClose = useCallback(() => navigate(-1), [navigate]);
+  const { displayTrack, displayArtist, albumName, cachedArt, dominantColor, progressPct, durationMs } =
+    useNowPlaying(playback);
+
+  const elapsedMs = Math.round((progressPct / 100) * durationMs) + 250;
+
+  const { lines, isLoading: lyricsLoading, isInstrumental, notFound } =
+    useLyrics(displayTrack, displayArtist, albumName, durationMs);
+
+  const { description } = useGeniusDescription(displayTrack, displayArtist);
+
+  const activeLine = lines.reduce((acc, l, i) => (l.timeMs <= elapsedMs ? i : acc), -1);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lineRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const hasScrolledRef = useRef(false);
+
+  useEffect(() => {
+    if (activeLine < 0) return;
+    const container = containerRef.current;
+    const line = lineRefs.current[activeLine];
+    if (!container || !line) return;
+    const cr = container.getBoundingClientRect();
+    const lr = line.getBoundingClientRect();
+    const target = container.scrollTop + lr.top - cr.top - cr.height / 2 + lr.height / 2;
+    container.scrollTo({ top: Math.max(0, target), behavior: hasScrolledRef.current ? 'smooth' : 'instant' });
+    hasScrolledRef.current = true;
+  }, [activeLine]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className={styles.overlay}
+      style={dominantColor ? ({ '--dc': dominantColor } as React.CSSProperties) : undefined}
+    >
+      {cachedArt && <img className={styles.bgArt} src={cachedArt} alt="" />}
+      <div className={styles.waveBg} />
+      <div className={styles.vignette} />
+
+      <button className={styles.closeBtn} onClick={onClose} title="Close (Esc)">
+        <X size={18} />
+      </button>
+
+      <div className={styles.content}>
+        {/* Left — art + metadata + genius description */}
+        <div className={styles.leftPanel} style={{ '--tc': textColor(dominantColor) } as React.CSSProperties}>
+          {cachedArt ? (
+            <img className={styles.bigArt} src={cachedArt} alt="" />
+          ) : (
+            <div className={styles.bigArtPh}><Music2 size={48} /></div>
+          )}
+          <div className={styles.meta}>
+            <div className={styles.metaTrack}>{displayTrack || '—'}</div>
+            <div className={styles.metaArtist}>{displayArtist || '—'}</div>
+          </div>
+          {description && (
+            <div className={styles.geniusDesc}>
+              {renderDom(description, 0)}
+            </div>
+          )}
+        </div>
+
+        {/* Right — scrolling lyrics */}
+        <div ref={containerRef} className={styles.lyricsContainer}>
+          {lyricsLoading && (
+            <div className={styles.loadingWrap}>
+              <div className={styles.loadingIcon}><Mic size={36} /></div>
+              <div className={styles.loadingLabel}>Loading</div>
+              <div className={styles.dots}>
+                <span /><span /><span />
+              </div>
+            </div>
+          )}
+          <div className={styles.lyricsPad}>
+            {!lyricsLoading && isInstrumental && <div className={styles.status}>♪ Instrumental ♪</div>}
+            {!lyricsLoading && notFound && !isInstrumental && <div className={styles.status}>No lyrics found</div>}
+            {lines.map((line, i) => {
+              const dist = Math.abs(i - activeLine);
+              return (
+                <div
+                  key={i}
+                  ref={(el) => { lineRefs.current[i] = el; }}
+                  className={`${styles.line}${i === activeLine ? ' ' + styles.lineActive : ''}`}
+                  style={activeLine >= 0 ? { opacity: Math.max(0.18, 1 - dist * 0.19) } : undefined}
+                >
+                  {line.text}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/renderer/src/components/PlayerBar.tsx
+++ b/renderer/src/components/PlayerBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { getActiveProvider } from "../providers";
 import { useNowPlaying } from "../hooks/useNowPlaying";
 import { useOpenItem } from "../hooks/useOpenItem";
@@ -18,6 +19,7 @@ import {
   List,
   Music,
   PictureInPicture2,
+  Mic,
 } from "lucide-react";
 import type { PlaybackState } from "../hooks/usePlayback";
 import styles from "../styles/PlayerBar.module.css";
@@ -139,12 +141,10 @@ function VolumeButton({ volume }: { volume: number }) {
   );
 }
 
-export function PlayerBar({
-  isAuthed,
-  playback,
-  onToggleQueue,
-  onShuffle,
-}: Props) {
+export function PlayerBar({ isAuthed, playback, onToggleQueue, onShuffle }: Props) {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const lyricsActive = pathname === '/lyrics';
   const openItem = useOpenItem();
   const {
     displayTrack, displayArtist, cachedArt, dominantColor,
@@ -294,9 +294,16 @@ export function PlayerBar({
           </button>
         </div>
 
-        {/* Right — volume + queue + mini player */}
+        {/* Right — volume + lyrics + queue + mini player */}
         <div className={styles.right}>
           <VolumeButton volume={volume} />
+          <button
+            className={`${styles.ctrl}${lyricsActive ? " " + styles.active : ""}`}
+            onClick={() => lyricsActive ? navigate(-1) : navigate('/lyrics')}
+            title="Lyrics"
+          >
+            <Mic size={14} />
+          </button>
           <button className={styles.ctrl} onClick={onToggleQueue} title="Queue">
             <List size={14} />
           </button>

--- a/renderer/src/components/__tests__/PlayerBar.test.tsx
+++ b/renderer/src/components/__tests__/PlayerBar.test.tsx
@@ -7,6 +7,11 @@ import type { PlaybackState } from '../../hooks/usePlayback';
 
 // ─── module mocks ────────────────────────────────────────────────────────────
 
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/' }),
+}));
+
 vi.mock('../../hooks/useNowPlaying', () => ({
   useNowPlaying: vi.fn(),
 }));

--- a/renderer/src/hooks/useGeniusDescription.ts
+++ b/renderer/src/hooks/useGeniusDescription.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function geniusDescriptionQueryOptions(
+  trackName: string | null | undefined,
+  artistName: string | null | undefined,
+) {
+  return {
+    queryKey: ['genius-description', trackName, artistName] as const,
+    queryFn: (): Promise<GeniusDomNode | null> =>
+      window.sonos.geniusDescription(trackName!, artistName!),
+    staleTime: Infinity,
+    retry: false,
+    enabled: !!trackName && !!artistName,
+  };
+}
+
+export function useGeniusDescription(
+  trackName: string | null | undefined,
+  artistName: string | null | undefined,
+) {
+  const { data, isLoading } = useQuery(
+    geniusDescriptionQueryOptions(trackName, artistName),
+  );
+  return { description: data ?? null, isLoading };
+}

--- a/renderer/src/hooks/useLyrics.ts
+++ b/renderer/src/hooks/useLyrics.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface LyricLine {
+  timeMs: number;
+  text: string;
+}
+
+function parseLrc(lrc: string): LyricLine[] {
+  return lrc.split('\n').flatMap((line) => {
+    const m = line.match(/^\[(\d{2}):(\d{2}(?:\.\d+)?)\](.*)/);
+    if (!m) return [];
+    const text = m[3].trim();
+    if (!text) return [];
+    return [{ timeMs: Math.round((Number(m[1]) * 60 + Number(m[2])) * 1000), text }];
+  });
+}
+
+type LyricsData = {
+  syncedLyrics: string | null;
+  plainLyrics: string | null;
+  instrumental: boolean;
+} | null;
+
+export function lyricsQueryOptions(
+  trackName: string | null | undefined,
+  artistName: string | null | undefined,
+  albumName: string | null | undefined,
+  durationMs: number,
+) {
+  return {
+    queryKey: ['lyrics', trackName, artistName, albumName] as const,
+    queryFn: async (): Promise<LyricsData> => {
+      const p = new URLSearchParams({ track_name: trackName!, artist_name: artistName! });
+      if (albumName) p.set('album_name', albumName);
+      if (durationMs) p.set('duration', String(Math.round(durationMs / 1000)));
+      const res = await fetch(`https://lrclib.net/api/get?${p}`);
+      if (res.status === 404) return null;
+      if (!res.ok) throw new Error(`LRCLIB ${res.status}`);
+      return res.json();
+    },
+    staleTime: Infinity,
+    retry: false,
+    enabled: !!trackName && !!artistName,
+  };
+}
+
+export function useLyrics(
+  trackName: string | null | undefined,
+  artistName: string | null | undefined,
+  albumName: string | null | undefined,
+  durationMs: number,
+) {
+  const { data, isLoading } = useQuery(lyricsQueryOptions(trackName, artistName, albumName, durationMs));
+
+  return {
+    lines: data?.syncedLyrics ? parseLrc(data.syncedLyrics) : [],
+    isLoading,
+    isInstrumental: data?.instrumental ?? false,
+    notFound: data === null && !isLoading,
+  };
+}

--- a/renderer/src/hooks/usePrefetchNextLyrics.ts
+++ b/renderer/src/hooks/usePrefetchNextLyrics.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { lyricsQueryOptions } from './useLyrics';
+import { geniusDescriptionQueryOptions } from './useGeniusDescription';
+import type { NormalizedQueueItem } from '../types/provider';
+
+export function usePrefetchNextLyrics(
+  items: NormalizedQueueItem[],
+  queueItemId: string | null,
+) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!queueItemId) return;
+    const next = items[Number(queueItemId)]; // queueItemId is 1-based, so index = id - 1 + 1 = id
+    if (!next) return;
+    const { title, artist, albumName, durationMs } = next.track;
+    queryClient.prefetchQuery(lyricsQueryOptions(title, artist, albumName, durationMs));
+    queryClient.prefetchQuery(geniusDescriptionQueryOptions(title, artist));
+  }, [queryClient, items, queueItemId]);
+}

--- a/renderer/src/styles/QueueSidebar.module.css
+++ b/renderer/src/styles/QueueSidebar.module.css
@@ -16,7 +16,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  z-index: 90;
+  z-index: 160;
   transform: translateX(calc(100% + 32px));
   transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/renderer/src/test/setup.ts
+++ b/renderer/src/test/setup.ts
@@ -60,6 +60,7 @@ Object.defineProperty(window, 'sonos', {
     getVersion:         vi.fn(pending),
     isNewVersion:       vi.fn(() => Promise.resolve(false)),
     openExternal:       vi.fn(() => Promise.resolve()),
+    geniusDescription:  vi.fn(() => Promise.resolve(null)),
     trackEvent:         vi.fn(() => Promise.resolve()),
     minimizeWindow:     vi.fn(() => Promise.resolve()),
     maximizeWindow:     vi.fn(() => Promise.resolve()),

--- a/renderer/src/types/globals.d.ts
+++ b/renderer/src/types/globals.d.ts
@@ -1,5 +1,7 @@
 // Ambient declarations for contextBridge APIs injected by preload.ts
 
+type GeniusDomNode = string | { tag: string; children?: GeniusDomNode[]; attributes?: Record<string, string> };
+
 interface AttributionEntry {
   user: string;
   timestamp: number;
@@ -258,6 +260,7 @@ interface SonosPreload {
   refreshAttribution: () => Promise<void>;
   onAttributionMap: (cb: (map: AttributionMap) => void) => Unsubscribe;
   onAttributionEvent: (cb: (event: AttributionEvent) => void) => Unsubscribe;
+  geniusDescription: (trackName: string, artistName: string) => Promise<GeniusDomNode | null>;
   /** Fire-and-forget telemetry event routed through the main process. No-op when App Insights is not configured. */
   trackEvent: (name: string, properties?: Record<string, string>) => Promise<void>;
   minimizeWindow:    () => Promise<void>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,6 @@
+import { config as loadEnv } from 'dotenv';
+loadEnv(); // loads .env from cwd (repo root) in dev; no-op if file absent
+
 import { app, BrowserWindow, ipcMain, safeStorage, session, shell, Menu, IpcMainInvokeEvent } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { officePubSub } from './pubsub';
@@ -1630,6 +1633,47 @@ ipcMain.handle('group:set', (_event: IpcMainInvokeEvent, groupId: string) => {
     wsSend({ namespace: 'groupVolume', groupId: group.id, command: 'subscribe' }, {}).catch(() => {});
   }
   return { ok: true };
+});
+
+// ─── Genius API ───────────────────────────────────────────────────────────────
+
+ipcMain.handle('genius:description', async (_: IpcMainInvokeEvent, trackName: string, artistName: string) => {
+  const key = process.env.GENIUS_ACCESS_TOKEN;
+  if (!key) {
+    log('[genius] GENIUS_ACCESS_TOKEN not set — skipping');
+    return null;
+  }
+
+  const debugReq = (id: string, url: string, ts: number) =>
+    httpDebugWin?.webContents.send('http:req', { id, ts, operationId: 'genius', method: 'GET', url, headers: { Authorization: 'Bearer ***' } });
+  const debugRes = (id: string, status: number, body: string, ts: number) =>
+    httpDebugWin?.webContents.send('http:res', { id, status, statusText: String(status), headers: {}, body, durationMs: Date.now() - ts });
+
+  try {
+    const searchUrl = `https://api.genius.com/search?q=${encodeURIComponent(`${trackName} ${artistName}`)}`;
+    const searchId = randomUUID(); const searchTs = Date.now();
+    debugReq(searchId, searchUrl, searchTs);
+    const searchRes = await fetch(searchUrl, { headers: { Authorization: `Bearer ${key}` } });
+    const searchBody = await searchRes.text();
+    debugRes(searchId, searchRes.status, searchBody, searchTs);
+    if (!searchRes.ok) return null;
+    const searchData = JSON.parse(searchBody) as { response: { hits: { result: { id: number } }[] } };
+    const songId = searchData.response?.hits?.[0]?.result?.id;
+    if (!songId) return null;
+
+    const songUrl = `https://api.genius.com/songs/${songId}`;
+    const songId2 = randomUUID(); const songTs = Date.now();
+    debugReq(songId2, songUrl, songTs);
+    const songRes = await fetch(songUrl, { headers: { Authorization: `Bearer ${key}` } });
+    const songBody = await songRes.text();
+    debugRes(songId2, songRes.status, songBody, songTs);
+    if (!songRes.ok) return null;
+    const songData = JSON.parse(songBody) as { response: { song: { description: { dom: unknown } } } };
+    return songData.response?.song?.description?.dom ?? null;
+  } catch (err) {
+    log(`[genius] error: ${err}`);
+    return null;
+  }
 });
 
 // ─── Application menu ────────────────────────────────────────────────────────

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -56,6 +56,7 @@ export interface SonosAPI {
   fetchGameDates: (userName: string) => Promise<unknown>;
   fetchMyScore: (gameId: string, userName: string) => Promise<unknown>;
   fetchGameStats: (date?: string) => Promise<unknown>;
+  geniusDescription: (trackName: string, artistName: string) => Promise<string | null>;
   trackEvent: (name: string, properties?: Record<string, string>) => Promise<void>;
   minimizeWindow:    () => Promise<void>;
   maximizeWindow:    () => Promise<void>;
@@ -170,6 +171,8 @@ contextBridge.exposeInMainWorld('sonos', {
     ipcRenderer.on('attribution:event', listener);
     return () => ipcRenderer.removeListener('attribution:event', listener);
   },
+  geniusDescription: (trackName: string, artistName: string) =>
+    ipcRenderer.invoke('genius:description', trackName, artistName),
   trackEvent: (name: string, properties?: Record<string, string>) =>
     ipcRenderer.invoke('telemetry:event', name, properties),
   minimizeWindow:    () => ipcRenderer.invoke('win:minimize'),


### PR DESCRIPTION
## Summary

- Adds a full-screen `/lyrics` route (React Router) with LRCLIB time-synced lyrics — auto-scrolls to the current line, highlights it bold at 32px, dims surrounding lines by distance
- Left panel shows big album art, track/artist name, and Genius API song description rendered from the DOM tree (with clickable links opening in the system browser)
- Background derived from album art dominant colour: blurred art + coloured gradient + vignette; text colour (white vs dark) auto-selected by perceived brightness
- Mic button on the player bar navigates to/from `/lyrics`; navigating to any other tab naturally exits the panel
- Queue sidebar remains accessible over the lyrics panel (z-index bump)
- Pre-loads next track's lyrics and Genius description on queue position change via `usePrefetchNextLyrics`
- Loading state shows pulsating mic icon + animated dots (matching the TrueTunes splash style)
- Responsive: left panel hidden at ≤ 800px

## New files

| File | Purpose |
|---|---|
| `renderer/src/hooks/useLyrics.ts` | LRCLIB fetch + LRC parsing, React Query |
| `renderer/src/hooks/useGeniusDescription.ts` | Genius description fetch via IPC proxy, React Query |
| `renderer/src/hooks/usePrefetchNextLyrics.ts` | Pre-loads next track on queue change |
| `renderer/src/components/LyricsPanel.tsx` | Full-screen lyrics panel component |
| `renderer/src/components/LyricsPanel.module.css` | Panel styles |

## Test plan

- [ ] Play a track with synced lyrics (most mainstream songs) — panel opens, lyrics scroll and bold line follows playback
- [ ] Play an instrumental — "♪ Instrumental ♪" shown
- [ ] Play a track LRCLIB doesn't know — "No lyrics found" shown
- [ ] Genius description appears on left for known tracks; links open in browser
- [ ] Navigate away (browse, search) while lyrics panel open — panel closes, navigation works
- [ ] Queue opens on top of lyrics panel
- [ ] `GENIUS_ACCESS_TOKEN` not set — app still works, description just absent
- [ ] `npm run typecheck && npm run test:run` pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)