### PR TITLE
feat: docked queue only, lyrics panel fix, Genius CI secret

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,4 +117,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPINSIGHTS_CONNECTION_STRING: ${{ secrets.APPINSIGHTS_CONNECTION_STRING }}
+          GENIUS_ACCESS_TOKEN: ${{ secrets.GENIUS_ACCESS_TOKEN }}
           VITE_GITHUB_PAT: ${{ secrets.VITE_GITHUB_PAT }}

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -82,11 +82,9 @@ function MainApp() {
     reloadQueue();
   }, [playback.queueVersion, reloadQueue]);
 
-  const [queueOpen, setQueueOpen]       = useState(false);
   const [feedbackOpen, setFeedbackOpen]     = useState(false);
   const [changelogOpen, setChangelogOpen]   = useState(false);
   const [displayName, setDisplayName] = useState<string | null | undefined>(undefined); // undefined = not yet loaded
-  const [queueMode, setQueueMode] = useState<'floating' | 'docked'>('floating');
   const [queueDockedWidth, setQueueDockedWidth] = useState<number>(380);
   const queueSidebarRef = useRef<QueueSidebarHandle>(null);
   const shellRef = useRef<HTMLDivElement>(null);
@@ -96,12 +94,10 @@ function MainApp() {
 
 useEffect(() => {
     window.sonos.getDisplayName().then(setDisplayName);
-    window.sonos.getQueueMode().then(setQueueMode).catch(() => {});
     window.sonos.getQueueDockedWidth().then(setQueueDockedWidth).catch(() => {});
   }, []);
 
   useEffect(() => {
-    if (queueMode !== 'docked') return;
     function clamp() {
       const max = window.innerWidth - (800 + 64);
       setQueueDockedWidth((w) => (w > max ? max : w));
@@ -109,25 +105,12 @@ useEffect(() => {
     window.addEventListener('resize', clamp);
     clamp();
     return () => window.removeEventListener('resize', clamp);
-  }, [queueMode]);
-
-  const handleSetQueueMode = useCallback((mode: 'floating' | 'docked') => {
-    setQueueMode(mode);
-    window.sonos.setQueueMode(mode).catch(() => {});
   }, []);
 
   const handleSetQueueDockedWidth = useCallback((width: number) => {
     setQueueDockedWidth(width);
     window.sonos.setQueueDockedWidth(width).catch(() => {});
   }, []);
-
-  const handleQueueButton = useCallback(() => {
-    if (queueMode === 'docked') {
-      queueSidebarRef.current?.scrollToNowPlaying();
-    } else {
-      setQueueOpen((o) => !o);
-    }
-  }, [queueMode]);
 
   const splashReadyRef = useRef(false);
   useEffect(() => {
@@ -443,7 +426,7 @@ useEffect(() => {
     <div
       ref={shellRef}
       className={styles.shell}
-      style={queueMode === 'docked' ? { '--docked-queue-w': `${queueDockedWidth}px` } as React.CSSProperties : undefined}
+      style={{ '--docked-queue-w': `${queueDockedWidth}px` } as React.CSSProperties}
     >
       <Splash ready={splashReady} />
       <TopNav
@@ -451,8 +434,6 @@ useEffect(() => {
         groups={groups}
         activeGroupId={activeGroupId}
         onGroupChange={handleGroupChange}
-        queueOpen={queueOpen}
-        onToggleQueue={handleQueueButton}
         onResync={() => window.sonos.resync()}
         displayName={displayName}
         onSaveName={(name) => {
@@ -460,8 +441,6 @@ useEffect(() => {
           setDisplayName(name);
         }}
         onChangelogOpen={() => setChangelogOpen(true)}
-        queueMode={queueMode}
-        onSetQueueMode={handleSetQueueMode}
       />
       <div className={styles.body}>
         <Routes>
@@ -491,42 +470,15 @@ useEffect(() => {
               />
             }
           />
-          <Route path="/album/:id" element={<AlbumPanel onAddToQueue={handleAddToQueue} queueOpen={queueOpen || queueMode === 'docked'} />} />
+          <Route path="/album/:id" element={<AlbumPanel onAddToQueue={handleAddToQueue} />} />
           <Route path="/artist/:id" element={<ArtistPanel onAddToQueue={handleAddToQueue} />} />
           <Route path="/container/:id" element={<ContainerPanel onAddToQueue={handleAddToQueue} />} />
           <Route path="/leaderboard" element={<LeaderboardPanel />} />
           <Route path="/queuedle" element={<QueuedlePanel />} />
           <Route path="/lyrics" element={<LyricsPanel playback={playback} />} />
         </Routes>
-        {queueMode === 'docked' && (
-          <QueueSidebar
-            ref={queueSidebarRef}
-            mode="docked"
-            open
-            items={queueItems}
-            setItems={setQueueItems}
-            isLoading={queueLoading}
-            error={queueError}
-            currentObjectId={playback.currentObjectId}
-            currentQueueItemId={playback.queueItemId}
-            positionMs={playback.positionMs}
-            currentTrackDurationMs={playback.durationMs}
-            groupName={groups.find(g => g.id === activeGroupId)?.name ?? null}
-            onClose={() => {}}
-            onRefresh={reloadQueue}
-            onError={showToast}
-            onAddToQueue={handleAddToQueue}
-            dockedWidth={queueDockedWidth}
-            onResizeWidth={handleSetQueueDockedWidth}
-            onResizeWidthLive={handleResizeWidthLive}
-          />
-        )}
-      </div>
-      {queueMode === 'floating' && (
         <QueueSidebar
           ref={queueSidebarRef}
-          mode="floating"
-          open={queueOpen}
           items={queueItems}
           setItems={setQueueItems}
           isLoading={queueLoading}
@@ -536,18 +488,18 @@ useEffect(() => {
           positionMs={playback.positionMs}
           currentTrackDurationMs={playback.durationMs}
           groupName={groups.find(g => g.id === activeGroupId)?.name ?? null}
-          onClose={() => setQueueOpen(false)}
           onRefresh={reloadQueue}
           onError={showToast}
           onAddToQueue={handleAddToQueue}
+          dockedWidth={queueDockedWidth}
+          onResizeWidth={handleSetQueueDockedWidth}
+          onResizeWidthLive={handleResizeWidthLive}
         />
-      )}
+      </div>
       <PlayerBar
         isAuthed={isAuthed}
         playback={playback}
-        onToggleQueue={handleQueueButton}
         onShuffle={reloadQueue}
-        queueMode={queueMode}
       />
       {toastMsg && <div className={styles.toast}>{toastMsg}</div>}
       {displayName === null && (

--- a/renderer/src/components/HomePanel.tsx
+++ b/renderer/src/components/HomePanel.tsx
@@ -45,10 +45,10 @@ export async function fetchYtmSections(): Promise<YtmSections> {
   const rootItems = (stack?.['items'] ?? []) as SonosItem[];
 
   const find = (title: string) => rootItems.find((i) => (i.title ?? i.name) === title);
-  const homeItem        = find('Home');
+  const homeItem = find('Home');
   const newReleasesItem = find('New releases');
-  const chartsItem      = find('Charts');
-  const supermixItem    = find('My Supermix');
+  const chartsItem = find('Charts');
+  const supermixItem = find('My Supermix');
 
   const browseContainer = async (item: SonosItem | undefined): Promise<SonosItem[]> => {
     if (!item) return [];
@@ -72,7 +72,7 @@ export async function fetchYtmSections(): Promise<YtmSections> {
 
   return {
     forYou: supermixItem
-      ? [{ ...supermixItem, images: [] as { url: string }[], imageUrl: '/icon.png' }, ...homeItems]
+      ? [{ ...supermixItem, images: [] as { url: string }[], imageUrl: '../../public/icon.png' }, ...homeItems]
       : homeItems,
     newReleases: newItems,
     charts: chartItems,
@@ -81,11 +81,11 @@ export async function fetchYtmSections(): Promise<YtmSections> {
 
 export function HomePanel({ isAuthed, onAddToQueue, ytm, ytmLoading, history, histLoading }: Props) {
   const queryClient = useQueryClient();
-  const location    = useLocation();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
-  const openItem    = useOpenItem();
+  const openItem = useOpenItem();
 
-  const view         = location.pathname === '/search' ? 'search' : 'home';
+  const view = location.pathname === '/search' ? 'search' : 'home';
   const activeSearch = searchParams.get('q') ?? '';
 
   const { data: searchResults = [], isFetching: searchLoading } = useQuery({
@@ -122,10 +122,7 @@ export function HomePanel({ isAuthed, onAddToQueue, ytm, ytmLoading, history, hi
         {searchLoading ? (
           <div className={styles.msg}>Searching…</div>
         ) : (
-          <SearchResults
-            results={searchResults}
-            onAddToQueue={onAddToQueue}
-          />
+          <SearchResults results={searchResults} onAddToQueue={onAddToQueue} />
         )}
       </div>
     );

--- a/renderer/src/components/LyricsPanel.module.css
+++ b/renderer/src/components/LyricsPanel.module.css
@@ -56,6 +56,7 @@
   display: grid;
   grid-template-columns: 38% 62%;
   min-height: 0;
+  margin-right: var(--docked-queue-w, 0px);
 }
 
 /* ── Left panel ── */

--- a/renderer/src/components/PlayerBar.tsx
+++ b/renderer/src/components/PlayerBar.tsx
@@ -16,7 +16,6 @@ import {
   Volume1,
   Volume2,
   VolumeX,
-  List,
   Music,
   PictureInPicture2,
   MicVocal,
@@ -27,9 +26,7 @@ import styles from "../styles/PlayerBar.module.css";
 interface Props {
   isAuthed: boolean;
   playback: PlaybackState;
-  onToggleQueue: () => void;
   onShuffle: () => void;
-  queueMode?: 'floating' | 'docked';
 }
 
 function ScrollingText({
@@ -142,7 +139,7 @@ function VolumeButton({ volume }: { volume: number }) {
   );
 }
 
-export function PlayerBar({ isAuthed, playback, onToggleQueue, onShuffle, queueMode }: Props) {
+export function PlayerBar({ isAuthed, playback, onShuffle }: Props) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const lyricsActive = pathname === '/lyrics';
@@ -305,11 +302,6 @@ export function PlayerBar({ isAuthed, playback, onToggleQueue, onShuffle, queueM
           >
             <MicVocal size={14} />
           </button>
-          {queueMode !== 'docked' && (
-            <button className={styles.ctrl} onClick={onToggleQueue} title="Queue">
-              <List size={14} />
-            </button>
-          )}
           <button
             className={styles.ctrl}
             onClick={() => window.sonos.openMiniPlayer()}

--- a/renderer/src/components/TopNav.tsx
+++ b/renderer/src/components/TopNav.tsx
@@ -8,7 +8,6 @@ import {
   Search,
   X,
   User,
-  List,
   RefreshCw,
   Gamepad2,
   Lightbulb,
@@ -17,21 +16,16 @@ import {
 } from 'lucide-react';
 import type { NormalizedGroup } from '../types/provider';
 import styles from '../styles/TopNav.module.css';
-import { WindowControls } from './WindowControls';
 
 interface Props {
   isAuthed: boolean;
   groups: NormalizedGroup[];
   activeGroupId: string | null;
   onGroupChange: (groupId: string) => void;
-  queueOpen: boolean;
-  onToggleQueue: () => void;
   onResync: () => void;
   displayName: string | null | undefined;
   onSaveName: (name: string) => void;
   onChangelogOpen: () => void;
-  queueMode: 'floating' | 'docked';
-  onSetQueueMode: (mode: 'floating' | 'docked') => void;
 }
 
 export function TopNav({
@@ -39,14 +33,10 @@ export function TopNav({
   groups,
   activeGroupId,
   onGroupChange,
-  queueOpen,
-  onToggleQueue,
   onResync,
   displayName,
   onSaveName,
   onChangelogOpen,
-  queueMode,
-  onSetQueueMode,
 }: Props) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -265,21 +255,6 @@ export function TopNav({
                     >
                       Save
                     </button>
-                    <div className={styles.namePopoverLabel}>Queue display</div>
-                    <div className={styles.queueModeToggle}>
-                      <button
-                        className={`${styles.queueModeBtn}${queueMode === 'floating' ? ' ' + styles.queueModeBtnActive : ''}`}
-                        onClick={() => onSetQueueMode('floating')}
-                      >
-                        Floating
-                      </button>
-                      <button
-                        className={`${styles.queueModeBtn}${queueMode === 'docked' ? ' ' + styles.queueModeBtnActive : ''}`}
-                        onClick={() => onSetQueueMode('docked')}
-                      >
-                        Docked
-                      </button>
-                    </div>
                     <div className={styles.versionRow}>
                       {appVersion && <div className={styles.appVersion}>v{appVersion}</div>}
                     </div>
@@ -306,25 +281,10 @@ export function TopNav({
               </button>
             )}
 
-            {queueMode !== 'docked' && (
-              <button
-                className={`${styles.iconBtn}${queueOpen ? ' ' + styles.active : ''}`}
-                onClick={onToggleQueue}
-                title="Queue"
-              >
-                <List size={15} />
-              </button>
-            )}
           </div>
         </nav>
       </div>
 
-      {/* Window controls — fixed top-right when queue is floating; moved into the docked sidebar otherwise */}
-      {queueMode === 'floating' && (
-        <div className={styles.windowPill}>
-          <WindowControls />
-        </div>
-      )}
     </>
   );
 }

--- a/renderer/src/components/__tests__/PlayerBar.test.tsx
+++ b/renderer/src/components/__tests__/PlayerBar.test.tsx
@@ -79,7 +79,7 @@ function makeNowPlaying(overrides: Partial<ReturnType<typeof useNowPlaying>> = {
 function setup(
   playbackOverrides: Partial<PlaybackState> = {},
   nowPlayingOverrides: Partial<ReturnType<typeof useNowPlaying>> = {},
-  extraProps: { isAuthed?: boolean; onToggleQueue?: () => void; onShuffle?: () => void } = {}
+  extraProps: { isAuthed?: boolean; onShuffle?: () => void } = {}
 ) {
   vi.mocked(useNowPlaying).mockReturnValue(makeNowPlaying(nowPlayingOverrides) as ReturnType<typeof useNowPlaying>);
 
@@ -87,7 +87,6 @@ function setup(
   const props = {
     isAuthed: true,
     playback: makePlayback(playbackOverrides),
-    onToggleQueue: vi.fn(),
     onShuffle: vi.fn(),
     ...extraProps,
   };
@@ -127,7 +126,6 @@ describe('PlayerBar — visibility', () => {
         <PlayerBar
           isAuthed={true}
           playback={makePlayback()}
-          onToggleQueue={vi.fn()}
           onShuffle={vi.fn()}
         />
       </QueryClientProvider>
@@ -333,13 +331,6 @@ describe('PlayerBar — volume button', () => {
 // ─── right-side controls ─────────────────────────────────────────────────────
 
 describe('PlayerBar — right controls', () => {
-  it('Queue button calls onToggleQueue', async () => {
-    const onToggleQueue = vi.fn();
-    const { user } = setup({}, {}, { onToggleQueue });
-    await user.click(screen.getByTitle('Queue'));
-    expect(onToggleQueue).toHaveBeenCalled();
-  });
-
   it('Mini player button calls openMiniPlayer', async () => {
     const { user } = setup();
     await user.click(screen.getByTitle('Mini player'));

--- a/renderer/src/components/__tests__/TopNav.test.tsx
+++ b/renderer/src/components/__tests__/TopNav.test.tsx
@@ -18,14 +18,10 @@ const defaultProps = {
   groups: [{ id: 'g1', name: 'Living Room', coordinatorId: 'g1', providerId: 'sonos' as const }],
   activeGroupId: 'g1',
   onGroupChange: vi.fn(),
-  queueOpen: false,
-  onToggleQueue: vi.fn(),
   onResync: vi.fn(),
   displayName: 'Alice',
   onSaveName: vi.fn(),
   onChangelogOpen: vi.fn(),
-  queueMode: 'floating' as const,
-  onSetQueueMode: vi.fn(),
 };
 
 beforeEach(() => {
@@ -46,7 +42,6 @@ describe('TopNav', () => {
     render(<TopNav {...defaultProps} />);
     expect(screen.getByTitle('Home')).toBeInTheDocument();
     expect(screen.getByTitle('Leaderboard')).toBeInTheDocument();
-    expect(screen.getByTitle('Queue')).toBeInTheDocument();
   });
 
   it('navigates to /leaderboard when Leaderboard is clicked', async () => {
@@ -85,14 +80,6 @@ describe('TopNav', () => {
     render(<TopNav {...defaultProps} />);
     await user.click(screen.getByTitle('Clear'));
     expect(mockNavigate).toHaveBeenCalledWith('/');
-  });
-
-  it('calls onToggleQueue when Queue is clicked', async () => {
-    const onToggleQueue = vi.fn();
-    const user = userEvent.setup();
-    render(<TopNav {...defaultProps} onToggleQueue={onToggleQueue} />);
-    await user.click(screen.getByTitle('Queue'));
-    expect(onToggleQueue).toHaveBeenCalled();
   });
 
   it('calls onChangelogOpen when changelog button is clicked', async () => {
@@ -138,13 +125,6 @@ describe('TopNav', () => {
     render(<TopNav {...defaultProps} groups={[]} onResync={onResync} />);
     await user.click(screen.getByTitle('Reconnect'));
     expect(onResync).toHaveBeenCalled();
-  });
-
-  it('calls minimizeWindow on Minimise click', async () => {
-    const user = userEvent.setup();
-    render(<TopNav {...defaultProps} />);
-    await user.click(screen.getByTitle('Minimise'));
-    expect(window.sonos.minimizeWindow).toHaveBeenCalled();
   });
 
   it('shows app version in name popover after load', async () => {

--- a/renderer/src/components/album/AlbumPanel.tsx
+++ b/renderer/src/components/album/AlbumPanel.tsx
@@ -13,10 +13,9 @@ import styles from '../../styles/AlbumPanel.module.css';
 
 interface Props {
   onAddToQueue: (item: SonosItem) => Promise<void> | void;
-  queueOpen?: boolean;
 }
 
-export function AlbumPanel({ onAddToQueue, queueOpen }: Props) {
+export function AlbumPanel({ onAddToQueue }: Props) {
   const { state } = useLocation();
   const item = (state as { item?: SonosItem } | null)?.item;
   const navigate = useNavigate();
@@ -111,10 +110,6 @@ export function AlbumPanel({ onAddToQueue, queueOpen }: Props) {
     navigate(`/artist/${encodeURIComponent(rid?.objectId ?? '_')}`, { state: { item: data.artistItem } });
   }
 
-  const tracksStyle = queueOpen
-    ? { paddingRight: 'calc(clamp(300px, 22vw, 420px) + 32px)' }
-    : undefined;
-
   return (
     <div className={styles.panel}>
       <div className={styles.header} style={headerStyle}>
@@ -157,7 +152,7 @@ export function AlbumPanel({ onAddToQueue, queueOpen }: Props) {
 
       <div
         className={styles.tracks}
-        style={{ '--track-cols': isPlaylistOrProgram ? '24px 42px 1fr 260px 260px 50px 28px' : '24px 1fr 160px 50px 28px', ...tracksStyle } as React.CSSProperties}
+        style={{ '--track-cols': isPlaylistOrProgram ? '24px 42px 1fr 260px 260px 50px 28px' : '24px 1fr 160px 50px 28px' } as React.CSSProperties}
         onClick={() => { setSelected(new Set()); lastSelected.current = null; }}
       >
         {data && (

--- a/renderer/src/components/album/__tests__/AlbumPanel.test.tsx
+++ b/renderer/src/components/album/__tests__/AlbumPanel.test.tsx
@@ -184,12 +184,6 @@ describe('AlbumPanel', () => {
     expect(header?.style.background).toContain('200, 100, 50');
   });
 
-  it('queueOpen prop adds padding-right to tracks container', () => {
-    const { container } = render(<AlbumPanel onAddToQueue={vi.fn()} queueOpen />, { wrapper });
-    const tracks = container.querySelector('[class*="tracks"]') as HTMLElement;
-    expect(tracks?.style.paddingRight).toBeTruthy();
-  });
-
   // ── add to queue ──────────────────────────────────────────────────────────
 
   it('add to queue button calls onAddToQueue once with the album item (handler fans out per-track)', async () => {

--- a/renderer/src/components/queue/QueueSidebar.tsx
+++ b/renderer/src/components/queue/QueueSidebar.tsx
@@ -12,8 +12,6 @@ import type { SonosItem } from '../../types/sonos';
 import styles from '../../styles/QueueSidebar.module.css';
 
 interface Props {
-  mode: 'floating' | 'docked';
-  open: boolean;
   items: NormalizedQueueItem[];
   setItems: (updater: NormalizedQueueItem[] | ((prev: NormalizedQueueItem[]) => NormalizedQueueItem[])) => void;
   isLoading: boolean;
@@ -23,7 +21,6 @@ interface Props {
   positionMs?: number;
   currentTrackDurationMs?: number;
   groupName: string | null;
-  onClose: () => void;
   onRefresh: () => void;
   onError: (msg: string) => void;
   onAddToQueue: (item: SonosItem, position: number) => void;
@@ -42,8 +39,6 @@ const PLAYER_BAR_PADDING = 64; // 32px breathing room each side
 
 export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function QueueSidebar(
   {
-    mode,
-    open,
     items,
     setItems,
     isLoading,
@@ -53,7 +48,6 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
     positionMs = 0,
     currentTrackDurationMs = 0,
     groupName,
-    onClose,
     onRefresh,
     onError,
     onAddToQueue,
@@ -63,8 +57,7 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
   },
   ref
 ) {
-  const isDocked = mode === 'docked';
-  const isActive = isDocked || open;
+  const isActive = true;
 
   const contentRef = useRef<HTMLDivElement>(null);
   const attributionMap = useAttribution(onRefresh);
@@ -116,7 +109,7 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
 
   useImperativeHandle(ref, () => ({ scrollToNowPlaying }), []);
 
-  useEffect(() => { setSelected(new Set()); }, [open, items]);
+  useEffect(() => { setSelected(new Set()); }, [items]);
 
   useEffect(() => {
     if (!isActive) return;
@@ -154,7 +147,6 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
   }, [isActive, selected, setItems, onRefresh, onError]);
 
   function handleResizePointerDown(e: React.PointerEvent<HTMLDivElement>) {
-    if (!isDocked) return;
     e.preventDefault();
     const startX = e.clientX;
     const startWidth = liveWidthRef.current;
@@ -277,28 +269,24 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
   }
 
   const selCount = selected.size;
-  const sidebarClass = `${styles.sidebar}${isDocked ? ' ' + styles.docked : ''}${!isDocked && open ? ' ' + styles.open : ''}`;
-  const sidebarStyle = isDocked ? { width: liveWidth } : undefined;
+  const sidebarClass = styles.sidebar;
+  const sidebarStyle = { width: liveWidth };
 
   return (
     <div className={sidebarClass} style={sidebarStyle}>
-      {isDocked && (
-        <div
-          className={styles.resizeHandle}
-          onPointerDown={handleResizePointerDown}
-          onPointerMove={e => e.currentTarget.style.setProperty('--mouse-y', `${e.nativeEvent.offsetY}px`)}
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize queue"
-        />
-      )}
-      {isDocked && (
-        <div className={styles.dockedTopBar}>
-          <div className={styles.winPill}>
-            <WindowControls />
-          </div>
+      <div
+        className={styles.resizeHandle}
+        onPointerDown={handleResizePointerDown}
+        onPointerMove={e => e.currentTarget.style.setProperty('--mouse-y', `${e.nativeEvent.offsetY}px`)}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize queue"
+      />
+      <div className={styles.dockedTopBar}>
+        <div className={styles.winPill}>
+          <WindowControls />
         </div>
-      )}
+      </div>
       <div className={styles.header}>
         <span className={styles.title}>
           Queue{groupName ? ` · ${groupName}` : ''}{items.length > 0 ? ` · ${items.length}` : ''}
@@ -320,9 +308,6 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
             <button className={styles.iconBtn} onClick={scrollToNowPlaying} title="Jump to now playing">⊙</button>
             {items.length > 0 && (
               <button className={styles.iconBtn} title="Clear queue" onClick={() => setPendingClear(true)}>⊘</button>
-            )}
-            {!isDocked && (
-              <button className={styles.iconBtn} onClick={onClose} title="Close">✕</button>
             )}
           </div>
         )}

--- a/renderer/src/components/queue/__tests__/QueueSidebar.test.tsx
+++ b/renderer/src/components/queue/__tests__/QueueSidebar.test.tsx
@@ -67,8 +67,6 @@ function makeItem(i: number): NormalizedQueueItem {
 }
 
 const defaultProps = {
-  mode: 'floating' as const,
-  open: true,
   items: [makeItem(0), makeItem(1), makeItem(2)],
   setItems: vi.fn(),
   isLoading: false,
@@ -76,7 +74,6 @@ const defaultProps = {
   currentObjectId: null,
   currentQueueItemId: null,
   groupName: 'Living Room',
-  onClose: vi.fn(),
   onRefresh: vi.fn(),
   onError: vi.fn(),
   onAddToQueue: vi.fn(),
@@ -363,12 +360,6 @@ describe('QueueSidebar — header buttons', () => {
     expect(onRefresh).toHaveBeenCalled();
   });
 
-  it('Close button calls onClose', async () => {
-    const onClose = vi.fn();
-    const { user } = setup({ onClose });
-    await user.click(screen.getByTitle('Close'));
-    expect(onClose).toHaveBeenCalled();
-  });
 });
 
 // ─── items/open state ─────────────────────────────────────────────────────────

--- a/renderer/src/styles/PlayerBar.module.css
+++ b/renderer/src/styles/PlayerBar.module.css
@@ -1,4 +1,3 @@
-/* ── Floating glass bar ── */
 .bar {
   position: fixed;
   bottom: 24px;

--- a/renderer/src/styles/QueueSidebar.module.css
+++ b/renderer/src/styles/QueueSidebar.module.css
@@ -1,53 +1,15 @@
 .sidebar {
-  position: fixed;
-  top: calc(var(--nav-h) + 8px);
-  right: 16px;
-  bottom: 100px;
-  width: clamp(300px, 22vw, 420px);
-  background: rgba(12, 12, 18, 0.72);
-  backdrop-filter: blur(48px) saturate(200%) brightness(1.03);
-  will-change: backdrop-filter;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 22px;
-  box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.5),
-    0 1px 0 rgba(255, 255, 255, 0.06) inset,
-    0 -1px 0 rgba(0, 0, 0, 0.3) inset;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  z-index: 160;
-  transform: translateX(calc(100% + 32px));
-  transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.sidebar.open { transform: translateX(0); }
-
-@media (min-width: 1520px) {
-  .sidebar {
-    bottom: 12px;
-  }
-}
-
-/* ── Docked mode (right-side column inside .body flex row) ── */
-.sidebar.docked {
   position: relative;
-  top: auto; right: auto; bottom: auto;
-  width: auto;
   height: 100%;
   flex-shrink: 0;
   /* Always pin to the right of .body — even when the active route is out
      of flow (e.g. LyricsPanel uses position:fixed), the auto margin
      consumes any leftover space on the sidebar's left side. */
   margin-left: auto;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  backdrop-filter: none;
   background: transparent;
-  transform: none;
-  transition: none;
   overflow: visible;
+  display: flex;
+  flex-direction: column;
   /* Sit above the TopNav drag region (z-index 199) so the buttons below
      are clickable; the dockedTopBar provides its own drag region. */
   z-index: 200;
@@ -121,7 +83,7 @@
   flex-shrink: 0;
 }
 
-.sidebar.docked .header {
+.sidebar .header {
   order: 99;
   border-bottom: none;
   border-top: 1px solid var(--border);

--- a/renderer/src/test/setup.ts
+++ b/renderer/src/test/setup.ts
@@ -48,8 +48,6 @@ Object.defineProperty(window, 'sonos', {
     closeMiniPlayer:    vi.fn(() => Promise.resolve()),
     getDisplayName:     vi.fn(pending),
     setDisplayName:     vi.fn(pending),
-    getQueueMode:        vi.fn(() => Promise.resolve('floating')),
-    setQueueMode:        vi.fn(() => Promise.resolve()),
     getQueueDockedWidth: vi.fn(() => Promise.resolve(380)),
     setQueueDockedWidth: vi.fn(() => Promise.resolve()),
     publishQueued:      vi.fn(pending),

--- a/renderer/src/types/globals.d.ts
+++ b/renderer/src/types/globals.d.ts
@@ -216,8 +216,6 @@ interface SonosPreload {
   // Attribution / office presence
   getDisplayName: () => Promise<string | null>;
   setDisplayName: (name: string) => Promise<void>;
-  getQueueMode: () => Promise<'floating' | 'docked'>;
-  setQueueMode: (mode: 'floating' | 'docked') => Promise<void>;
   getQueueDockedWidth: () => Promise<number>;
   setQueueDockedWidth: (width: number) => Promise<void>;
   publishQueued: (item: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,8 +32,6 @@ interface AppConfig {
   displayName?: string;
   /** Last app version the user opened — used to detect first launch on a new version. */
   lastSeenVersion?: string;
-  /** Queue display mode — floating overlay vs docked right-side column. */
-  queueMode?: 'floating' | 'docked';
   /** Width (px) of the docked queue column. */
   queueDockedWidth?: number;
 }
@@ -65,7 +63,6 @@ async function loadConfig(): Promise<void> {
     if (typeof parsed.displayName === 'string') config.displayName = parsed.displayName;
     if (typeof parsed.lastSeenVersion === 'string') config.lastSeenVersion = parsed.lastSeenVersion;
     if (typeof parsed.preferredCoordinatorId === 'string') config.preferredCoordinatorId = parsed.preferredCoordinatorId;
-    if (parsed.queueMode === 'floating' || parsed.queueMode === 'docked') config.queueMode = parsed.queueMode;
     if (typeof parsed.queueDockedWidth === 'number') config.queueDockedWidth = parsed.queueDockedWidth;
   } catch {
     // No config file yet — use defaults
@@ -79,7 +76,6 @@ async function saveConfig(): Promise<void> {
       displayName: config.displayName,
       lastSeenVersion: config.lastSeenVersion,
       preferredCoordinatorId: config.preferredCoordinatorId,
-      queueMode: config.queueMode,
       queueDockedWidth: config.queueDockedWidth,
     };
     await fs.writeFile(configFilePath(), JSON.stringify(toSave, null, 2), 'utf8');
@@ -1219,12 +1215,6 @@ ipcMain.handle('config:setDisplayName', async (_: IpcMainInvokeEvent, name: stri
   await saveConfig();
   // Start pubsub now that we have a name (first-time setup path)
   initPubSub().catch(console.error);
-});
-
-ipcMain.handle('config:getQueueMode', () => config.queueMode ?? 'floating');
-ipcMain.handle('config:setQueueMode', async (_: IpcMainInvokeEvent, mode: 'floating' | 'docked') => {
-  config.queueMode = mode;
-  await saveConfig();
 });
 
 ipcMain.handle('config:getQueueDockedWidth', () => config.queueDockedWidth ?? 380);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -40,8 +40,6 @@ export interface SonosAPI {
   // Attribution / office presence
   getDisplayName: () => Promise<string | null>;
   setDisplayName: (name: string) => Promise<void>;
-  getQueueMode: () => Promise<'floating' | 'docked'>;
-  setQueueMode: (mode: 'floating' | 'docked') => Promise<void>;
   getQueueDockedWidth: () => Promise<number>;
   setQueueDockedWidth: (width: number) => Promise<void>;
   publishQueued: (item: { eventType: 'track' | 'album'; uri: string; trackName: string; artist: string; serviceId?: string; accountId?: string; artistId?: string; album?: string; albumId?: string; imageUrl?: string }) => Promise<void>;
@@ -152,8 +150,6 @@ contextBridge.exposeInMainWorld('sonos', {
   // Attribution / office presence
   getDisplayName: () => ipcRenderer.invoke('config:getDisplayName'),
   setDisplayName: (name) => ipcRenderer.invoke('config:setDisplayName', name),
-  getQueueMode: () => ipcRenderer.invoke('config:getQueueMode'),
-  setQueueMode: (mode: 'floating' | 'docked') => ipcRenderer.invoke('config:setQueueMode', mode),
   getQueueDockedWidth: () => ipcRenderer.invoke('config:getQueueDockedWidth'),
   setQueueDockedWidth: (width: number) => ipcRenderer.invoke('config:setQueueDockedWidth', width),
   publishQueued: (item) => ipcRenderer.invoke('pubsub:publishQueued', item),


### PR DESCRIPTION
## We Shall Fight in the Queue

We shall go on to the end. We shall fight in the home panel, we shall fight on the lyrics view and the album pages, we shall fight with growing confidence and growing strength in the sidebar — we shall defend our queue, whatever the cost may be.

We shall fight in the floating overlay — and we have **abolished it**, for it served us no longer. We shall fight on the docked panel, we shall fight in the resize handle, we shall fight on the right-hand column of the viewport; we shall never surrender the queue to ambiguity of mode.

## What We Have Done

**We have eliminated floating mode.** The queue is docked. It has always been docked. It shall always be docked. The toggle is gone. The conditional rendering is gone. 257 lines have been deleted and 39 put in their place. This is not a defeat — this is a liberation.

**We have fixed the lyrics panel.** It had been skulking beneath the queue sidebar, an affront to the eye and to the layout engine. The background now sweeps magnificently across the full viewport — even behind the queue — while the content itself knows its place and stops at the queue's left edge. Order has been restored.

**We have brought the Genius token to the front.** It had been left behind in the pipeline, forgotten — a secret that was secret even from the build that needed it. `GENIUS_ACCESS_TOKEN` now marches alongside its brethren in the publish workflow. The descriptions shall flow.

**We have fixed the supermix icon path**, for even in victory one must tend to the small things.

## Test Plan

- [ ] Queue sidebar is always docked — no mode toggle anywhere in settings
- [ ] Lyrics panel background fills full viewport width (including behind queue)
- [ ] Lyrics content does not overlap the queue sidebar
- [ ] Genius descriptions load on the lyrics panel in a production build
- [ ] All 708 tests pass (`npm run test:run`)
- [ ] Typecheck clean (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)