### PR TITLE
Release 1.0.34 — Entra auth, profiles, playlists, Genius artist pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,3 +119,5 @@ jobs:
           APPINSIGHTS_CONNECTION_STRING: ${{ secrets.APPINSIGHTS_CONNECTION_STRING }}
           GENIUS_ACCESS_TOKEN: ${{ secrets.GENIUS_ACCESS_TOKEN }}
           VITE_GITHUB_PAT: ${{ secrets.VITE_GITHUB_PAT }}
+          ENTRA_CLIENT_ID: ${{ secrets.ENTRA_CLIENT_ID }}
+          ENTRA_TENANT_ID: ${{ secrets.ENTRA_TENANT_ID }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "true-tunes-2",
       "version": "1.0.34",
       "dependencies": {
+        "@azure/msal-node": "^5.2.2",
         "applicationinsights": "^3.14.0",
         "dompurify": "^3.4.1",
         "dotenv": "^17.4.2",
@@ -417,17 +418,25 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.3.tgz",
-      "integrity": "sha512-LqT8mRZpEils9zGR9eW+Ljqifh2aMA99UF/X0jxIKDYZeHr6onlHwhVP4xHCeLhh55BI63JCbdf1iWJbMh1mPw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "dist/main.js",
   "scripts": {
-    "build:main": "tsc && node -e \"const fs=require('fs');fs.copyFileSync('src/debug-ws.html','dist/debug-ws.html');fs.copyFileSync('src/debug-http.html','dist/debug-http.html');fs.writeFileSync('dist/build-env.json',JSON.stringify({GENIUS_ACCESS_TOKEN:process.env.GENIUS_ACCESS_TOKEN||'',APPINSIGHTS_CONNECTION_STRING:process.env.APPINSIGHTS_CONNECTION_STRING||''}))\"",
+    "build:main": "tsc && node -e \"require('dotenv').config();const fs=require('fs');fs.copyFileSync('src/debug-ws.html','dist/debug-ws.html');fs.copyFileSync('src/debug-http.html','dist/debug-http.html');fs.writeFileSync('dist/build-env.json',JSON.stringify({GENIUS_ACCESS_TOKEN:process.env.GENIUS_ACCESS_TOKEN||'',APPINSIGHTS_CONNECTION_STRING:process.env.APPINSIGHTS_CONNECTION_STRING||'',ENTRA_CLIENT_ID:process.env.ENTRA_CLIENT_ID||'',ENTRA_TENANT_ID:process.env.ENTRA_TENANT_ID||''}))\"",
     "build:renderer": "vite build --config renderer/vite.config.ts",
     "build": "npm run build:main && npm run build:renderer",
     "dev:renderer": "vite --config renderer/vite.config.ts",
@@ -32,6 +32,7 @@
     "typecheck": "tsc --noEmit && tsc --noEmit --project renderer/tsconfig.json"
   },
   "dependencies": {
+    "@azure/msal-node": "^5.2.2",
     "applicationinsights": "^3.14.0",
     "dompurify": "^3.4.1",
     "dotenv": "^17.4.2",

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -34,7 +34,6 @@ import { LeaderboardPanel } from './components/LeaderboardPanel';
 import { QueuedlePanel } from './components/queuedle/QueuedlePanel';
 import { QueueSidebar, type QueueSidebarHandle } from './components/queue/QueueSidebar';
 import { MiniPlayerShell } from './components/MiniPlayer';
-import { DisplayNameModal } from './components/DisplayNameModal';
 import { FeedbackDialog } from './components/FeedbackDialog';
 import { ChangelogDialog } from './components/ChangelogDialog';
 import { LyricsPanel } from './components/LyricsPanel';
@@ -89,6 +88,8 @@ function MainApp() {
   const [feedbackOpen, setFeedbackOpen]     = useState(false);
   const [changelogOpen, setChangelogOpen]   = useState(false);
   const [displayName, setDisplayName] = useState<string | null | undefined>(undefined); // undefined = not yet loaded
+  const [entraUser, setEntraUser] = useState<EntraUser | null | undefined>(undefined);
+  const [entraLoading, setEntraLoading] = useState(false);
   useEnsureFavourites(displayName);
   const [queueDockedWidth, setQueueDockedWidth] = useState<number>(380);
   const queueSidebarRef = useRef<QueueSidebarHandle>(null);
@@ -99,7 +100,12 @@ function MainApp() {
 
 useEffect(() => {
     window.sonos.getDisplayName().then(setDisplayName);
+    window.sonos.getEntraUser().then(setEntraUser).catch(() => setEntraUser(null));
     window.sonos.getQueueDockedWidth().then(setQueueDockedWidth).catch(() => {});
+    return window.sonos.onEntraReady((user) => {
+      setEntraUser(user);
+      window.sonos.getDisplayName().then(setDisplayName).catch(() => {});
+    });
   }, []);
 
   useEffect(() => {
@@ -435,8 +441,9 @@ useEffect(() => {
         displayName={displayName}
         onSaveName={(name) => {
           const stored = name.trim();
-          window.sonos.setDisplayName(stored).catch(() => {});
-          setDisplayName(stored || null);
+          void window.sonos.setDisplayName(stored).then((result) => {
+            if (!result?.error) setDisplayName(stored || null);
+          }).catch(() => {});
         }}
         onChangelogOpen={() => setChangelogOpen(true)}
       />
@@ -472,7 +479,7 @@ useEffect(() => {
           <Route path="/leaderboard" element={<LeaderboardPanel />} />
           <Route path="/queuedle" element={<QueuedlePanel />} />
           <Route path="/lyrics" element={<LyricsPanel playback={playback} />} />
-          <Route path="/profile/:userName" element={<ProfilePanel onAddToQueue={handleAddToQueue} displayName={displayName} onSignOut={() => { window.sonos.setDisplayName('').catch(() => {}); setDisplayName(null); }} />} />
+          <Route path="/profile/:userName" element={<ProfilePanel onAddToQueue={handleAddToQueue} displayName={displayName} onSignOut={async () => { setDisplayName(null); setEntraUser(null); setEntraLoading(true); await window.sonos.entraSignOut().catch(() => {}); await window.sonos.entraReLogin().catch(() => {}); const name = await window.sonos.getDisplayName().catch(() => null); setDisplayName(name); setEntraLoading(false); }} onChangeName={async (name) => { const result = await window.sonos.renameUser(displayName ?? '', name).catch(() => ({ error: 'network' })); if (!result?.error) setDisplayName(name); return result?.error ? { error: result.error } : null; }} />} />
           <Route path="/playlist/:id" element={<PlaylistPanel displayName={displayName} onAddToQueue={handleAddToQueue} />} />
         </Routes>
         <QueueSidebar
@@ -501,15 +508,10 @@ useEffect(() => {
         displayName={displayName}
       />
       {toastMsg && <div className={styles.toast}>{toastMsg}</div>}
-      {displayName === null && (
-        <DisplayNameModal
-          onSave={(name) => {
-            window.sonos.setDisplayName(name).catch(() => {
-              /* silent */
-            });
-            setDisplayName(name);
-          }}
-        />
+      {entraLoading && (
+        <div className={styles.entraSigningIn}>
+          <span>Signing in with your organisation account…</span>
+        </div>
       )}
       {feedbackOpen && <FeedbackDialog onClose={() => setFeedbackOpen(false)} />}
       {changelogOpen && <ChangelogDialog onClose={() => setChangelogOpen(false)} />}

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -88,7 +88,6 @@ function MainApp() {
   const [feedbackOpen, setFeedbackOpen]     = useState(false);
   const [changelogOpen, setChangelogOpen]   = useState(false);
   const [displayName, setDisplayName] = useState<string | null | undefined>(undefined); // undefined = not yet loaded
-  const [entraUser, setEntraUser] = useState<EntraUser | null | undefined>(undefined);
   const [entraLoading, setEntraLoading] = useState(false);
   useEnsureFavourites(displayName);
   const [queueDockedWidth, setQueueDockedWidth] = useState<number>(380);
@@ -100,10 +99,8 @@ function MainApp() {
 
 useEffect(() => {
     window.sonos.getDisplayName().then(setDisplayName);
-    window.sonos.getEntraUser().then(setEntraUser).catch(() => setEntraUser(null));
     window.sonos.getQueueDockedWidth().then(setQueueDockedWidth).catch(() => {});
-    return window.sonos.onEntraReady((user) => {
-      setEntraUser(user);
+    return window.sonos.onEntraReady(() => {
       window.sonos.getDisplayName().then(setDisplayName).catch(() => {});
     });
   }, []);
@@ -479,7 +476,7 @@ useEffect(() => {
           <Route path="/leaderboard" element={<LeaderboardPanel />} />
           <Route path="/queuedle" element={<QueuedlePanel />} />
           <Route path="/lyrics" element={<LyricsPanel playback={playback} />} />
-          <Route path="/profile/:userName" element={<ProfilePanel onAddToQueue={handleAddToQueue} displayName={displayName} onSignOut={async () => { setDisplayName(null); setEntraUser(null); setEntraLoading(true); await window.sonos.entraSignOut().catch(() => {}); await window.sonos.entraReLogin().catch(() => {}); const name = await window.sonos.getDisplayName().catch(() => null); setDisplayName(name); setEntraLoading(false); }} onChangeName={async (name) => { const result = await window.sonos.renameUser(displayName ?? '', name).catch(() => ({ error: 'network' })); if (!result?.error) setDisplayName(name); return result?.error ? { error: result.error } : null; }} />} />
+          <Route path="/profile/:userName" element={<ProfilePanel onAddToQueue={handleAddToQueue} displayName={displayName} onSignOut={async () => { setDisplayName(null); setEntraLoading(true); await window.sonos.entraSignOut().catch(() => {}); await window.sonos.entraReLogin().catch(() => {}); const name = await window.sonos.getDisplayName().catch(() => null); setDisplayName(name); setEntraLoading(false); }} onChangeName={async (name) => { const result = await window.sonos.renameUser(displayName ?? '', name).catch(() => ({ error: 'network' })); if (!result?.error) setDisplayName(name); return result?.error ? { error: result.error } : null; }} />} />
           <Route path="/playlist/:id" element={<PlaylistPanel displayName={displayName} onAddToQueue={handleAddToQueue} />} />
         </Routes>
         <QueueSidebar

--- a/renderer/src/components/DisplayNameModal.tsx
+++ b/renderer/src/components/DisplayNameModal.tsx
@@ -2,16 +2,26 @@ import { useState } from 'react';
 import styles from '../styles/DisplayNameModal.module.css';
 
 interface Props {
-  onSave: (name: string) => void;
+  onSave: (name: string) => Promise<{ error: string } | null>;
+  defaultName?: string;
 }
 
-export function DisplayNameModal({ onSave }: Props) {
-  const [value, setValue] = useState('');
+export function DisplayNameModal({ onSave, defaultName }: Props) {
+  const [value, setValue] = useState(defaultName ?? '');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = value.trim();
-    if (trimmed) onSave(trimmed);
+    if (!trimmed) return;
+    setSaving(true);
+    setError(null);
+    const result = await onSave(trimmed);
+    setSaving(false);
+    if (result?.error === 'taken') {
+      setError('That name is already taken — try another.');
+    }
   };
 
   return (
@@ -20,7 +30,7 @@ export function DisplayNameModal({ onSave }: Props) {
         <div className={styles.icon}>🎵</div>
         <h2 className={styles.heading}>What should we call you?</h2>
         <p className={styles.sub}>
-          Your name shows on tracks you add to the shared queue.
+          Your name shows on tracks you add to the shared queue. Defaults to your organisation account name.
         </p>
         <form onSubmit={handleSubmit} className={styles.form}>
           <input
@@ -28,13 +38,14 @@ export function DisplayNameModal({ onSave }: Props) {
             type="text"
             placeholder="Your name"
             value={value}
-            onChange={(e) => setValue(e.target.value)}
+            onChange={(e) => { setValue(e.target.value); setError(null); }}
             autoFocus
             maxLength={32}
             spellCheck={false}
           />
-          <button className={styles.btn} type="submit" disabled={!value.trim()}>
-            Let's go
+          {error && <p className={styles.error}>{error}</p>}
+          <button className={styles.btn} type="submit" disabled={!value.trim() || saving}>
+            {saving ? 'Saving…' : "Let's go"}
           </button>
         </form>
       </div>

--- a/renderer/src/components/PlayerBar.tsx
+++ b/renderer/src/components/PlayerBar.tsx
@@ -21,6 +21,8 @@ import {
   PictureInPicture2,
   MicVocal,
   Heart,
+  ChevronUp,
+  ChevronDown,
 } from "lucide-react";
 import type { PlaybackState } from "../hooks/usePlayback";
 import styles from "../styles/PlayerBar.module.css";
@@ -84,7 +86,8 @@ function VolumeButton({ volume }: { volume: number }) {
   const [open, setOpen] = useState(false);
   const [localVol, setLocalVol] = useState(volume);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const wrapRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const preMuteRef = useRef<number>(volume > 0 ? volume : 50);
 
   // Sync incoming WS volume only when the user isn't actively dragging
   const dragging = useRef(false);
@@ -92,9 +95,7 @@ function VolumeButton({ volume }: { volume: number }) {
     if (!dragging.current) setLocalVol(volume);
   }, [volume]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const val = Number(e.target.value);
-    setLocalVol(val);
+  const commitVolume = (val: number) => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       getActiveProvider().setVolume(val);
@@ -102,22 +103,75 @@ function VolumeButton({ volume }: { volume: number }) {
     }, 150);
   };
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = Number(e.target.value);
+    setLocalVol(val);
+    if (val > 0) preMuteRef.current = val;
+    commitVolume(val);
+  };
+
+  const step = (delta: number) => {
+    setLocalVol((prev) => {
+      const next = Math.max(0, Math.min(100, prev + delta));
+      if (next === prev) return prev;
+      if (next > 0) preMuteRef.current = next;
+      commitVolume(next);
+      return next;
+    });
+  };
+
+  const toggleMute = () => {
+    if (localVol > 0) {
+      preMuteRef.current = localVol;
+      setLocalVol(0);
+      commitVolume(0);
+    } else {
+      const restored = preMuteRef.current > 0 ? preMuteRef.current : 50;
+      setLocalVol(restored);
+      commitVolume(restored);
+    }
+  };
+
+  const handleEnter = () => {
+    if (closeRef.current) {
+      clearTimeout(closeRef.current);
+      closeRef.current = null;
+    }
+    setOpen(true);
+  };
+
+  const handleLeave = () => {
+    if (closeRef.current) clearTimeout(closeRef.current);
+    closeRef.current = setTimeout(() => setOpen(false), 150);
+  };
+
   useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+    return () => {
+      if (closeRef.current) clearTimeout(closeRef.current);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
+  }, []);
+
+  const muted = localVol === 0;
 
   return (
-    <div ref={wrapRef} className={styles.volWrap}>
+    <div
+      className={styles.volWrap}
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+    >
       {open && (
         <div className={styles.volPopover}>
           <span className={styles.volPct}>{localVol}</span>
+          <button
+            className={styles.volStep}
+            onClick={() => step(+1)}
+            disabled={localVol >= 100}
+            title="Volume up"
+            aria-label="Volume up"
+          >
+            <ChevronUp size={14} />
+          </button>
           <input
             className={styles.volSliderV}
             type="range"
@@ -129,12 +183,22 @@ function VolumeButton({ volume }: { volume: number }) {
             }}
             onChange={handleChange}
           />
+          <button
+            className={styles.volStep}
+            onClick={() => step(-1)}
+            disabled={localVol <= 0}
+            title="Volume down"
+            aria-label="Volume down"
+          >
+            <ChevronDown size={14} />
+          </button>
         </div>
       )}
       <button
         className={styles.ctrl}
-        onClick={() => setOpen((o) => !o)}
-        title="Volume"
+        onClick={toggleMute}
+        title={muted ? "Unmute" : "Mute"}
+        aria-label={muted ? "Unmute" : "Mute"}
       >
         <VolumeIconGlyph volume={localVol} />
       </button>
@@ -151,7 +215,7 @@ export function PlayerBar({ isAuthed, playback, onShuffle, displayName }: Props)
     displayTrack, displayArtist, cachedArt, dominantColor,
     elapsedLabel, durationLabel, progressPct, durationMs,
     isPlaying, isVisible, shuffle, repeat, volume, isExplicit,
-    albumItem, prefetchAlbum,
+    albumItem, artistItem, prefetchAlbum,
     currentObjectId, currentServiceId, currentAccountId, artUrlRaw,
   } = useNowPlaying(playback);
 
@@ -218,17 +282,27 @@ export function PlayerBar({ isAuthed, playback, onShuffle, displayName }: Props)
             )}
           </div>
           <div className={styles.trackInfo}>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                overflow: "hidden",
-              }}
-            >
+            <div className={styles.trackLine}>
               <ScrollingText
-                text={`${displayTrack || "—"}${displayArtist ? ` - ${displayArtist}` : ""}`}
+                text={displayTrack || "—"}
                 className={styles.trackName}
               />
+              {displayArtist && (
+                <>
+                  <span className={styles.trackSep}>{' – '}</span>
+                  {artistItem ? (
+                    <button
+                      type="button"
+                      className={styles.trackArtist}
+                      onClick={() => openItem(artistItem)}
+                    >
+                      {displayArtist}
+                    </button>
+                  ) : (
+                    <span className={styles.trackArtist}>{displayArtist}</span>
+                  )}
+                </>
+              )}
               {isExplicit && <ExplicitBadge />}
             </div>
             <div className={styles.progressSection}>

--- a/renderer/src/components/ProfilePanel.tsx
+++ b/renderer/src/components/ProfilePanel.tsx
@@ -61,13 +61,18 @@ interface Props {
   onAddToQueue: (item: SonosItem) => void;
   displayName?: string | null;
   onSignOut?: () => void;
+  onChangeName?: (name: string) => Promise<{ error: string } | null>;
 }
 
-export function ProfilePanel({ onAddToQueue, displayName, onSignOut }: Props) {
+export function ProfilePanel({ onAddToQueue, displayName, onSignOut, onChangeName }: Props) {
   const { userName } = useParams<{ userName: string }>();
   const navigate = useNavigate();
   const openItem = useOpenItem();
   const [createPlaylistOpen, setCreatePlaylistOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState('');
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [renameSaving, setRenameSaving] = useState(false);
 
 const { topTracks, artistItems: topArtists, albumItems: topAlbums, totalEvents, isLoading: statsLoading } =
     useUserStats(userName, 25);
@@ -122,6 +127,22 @@ const { topTracks, artistItems: topArtists, albumItems: topAlbums, totalEvents, 
     }
   }
 
+  async function handleRenameSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = renameValue.trim();
+    if (!trimmed || !onChangeName) return;
+    setRenameSaving(true);
+    setRenameError(null);
+    const result = await onChangeName(trimmed);
+    setRenameSaving(false);
+    if (result?.error === 'taken') {
+      setRenameError('That name is already taken.');
+    } else {
+      setRenaming(false);
+      navigate(`/profile/${trimmed}`);
+    }
+  }
+
   const { owned: ownedPlaylists, joined: joinedPlaylists } = useMyPlaylists(userName);
   const allPlaylists = isOwnProfile
     ? [...ownedPlaylists, ...joinedPlaylists]
@@ -164,16 +185,42 @@ const { topTracks, artistItems: topArtists, albumItems: topAlbums, totalEvents, 
         </div>
         <div className={styles.headerInfo}>
           <div className={styles.nameWrap}>
-            <h1 className={styles.userName}>{userName}</h1>
+            {renaming ? (
+              <form onSubmit={handleRenameSubmit} className={styles.renameForm}>
+                <input
+                  className={styles.renameInput}
+                  value={renameValue}
+                  onChange={e => { setRenameValue(e.target.value); setRenameError(null); }}
+                  autoFocus
+                  maxLength={32}
+                  spellCheck={false}
+                />
+                <button type="submit" className={styles.renameBtn} disabled={!renameValue.trim() || renameSaving}>
+                  {renameSaving ? '…' : 'Save'}
+                </button>
+                <button type="button" className={styles.renameCancelBtn} onClick={() => { setRenaming(false); setRenameError(null); }}>
+                  Cancel
+                </button>
+                {renameError && <span className={styles.renameError}>{renameError}</span>}
+              </form>
+            ) : (
+              <h1 className={styles.userName}>{userName}</h1>
+            )}
           </div>
           {(totalEvents > 0 || isOwnProfile) && (
             <span className={styles.statChip}>
               {totalEvents > 0 && (
                 <><span className={styles.statChipValue}>{totalEvents.toLocaleString()}</span> plays</>
               )}
-              {isOwnProfile && onSignOut && (
+              {isOwnProfile && onChangeName && !renaming && (
                 <>
                   {totalEvents > 0 && <span className={styles.statChipSep}>|</span>}
+                  <button className={styles.changeNameInline} onClick={() => { setRenameValue(userName ?? ''); setRenaming(true); }}>Change name</button>
+                </>
+              )}
+              {isOwnProfile && onSignOut && (
+                <>
+                  <span className={styles.statChipSep}>|</span>
                   <button className={styles.signOutInline} onClick={onSignOut}>Sign out</button>
                 </>
               )}

--- a/renderer/src/components/__tests__/PlayerBar.test.tsx
+++ b/renderer/src/components/__tests__/PlayerBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { PlayerBar } from '../PlayerBar';
@@ -144,7 +144,8 @@ describe('PlayerBar — visibility', () => {
 describe('PlayerBar — track info', () => {
   it('displays track and artist name', () => {
     setup();
-    expect(screen.getByText('Test Track - Test Artist')).toBeInTheDocument();
+    expect(screen.getByText('Test Track')).toBeInTheDocument();
+    expect(screen.getByText('Test Artist')).toBeInTheDocument();
   });
 
   it('shows elapsed and duration labels', () => {
@@ -307,24 +308,41 @@ describe('PlayerBar — seek bar', () => {
 // ─── volume ───────────────────────────────────────────────────────────────────
 
 describe('PlayerBar — volume button', () => {
-  it('clicking Volume button shows the popover', async () => {
-    const { user } = setup();
-    await user.click(screen.getByTitle('Volume'));
+  it('hovering the Volume button shows the popover', () => {
+    const { container } = setup();
+    const wrap = container.querySelector('[class*="volWrap"]') as HTMLElement;
+    fireEvent.mouseEnter(wrap);
     expect(screen.getByRole('slider')).toBeInTheDocument();
   });
 
-  it('clicking outside volume popover closes it', async () => {
-    const { user } = setup();
-    await user.click(screen.getByTitle('Volume'));
+  it('moving the mouse away closes the popover after a delay', async () => {
+    const { container } = setup();
+    const wrap = container.querySelector('[class*="volWrap"]') as HTMLElement;
+    fireEvent.mouseEnter(wrap);
     expect(screen.getByRole('slider')).toBeInTheDocument();
-    await user.click(document.body);
-    expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+    fireEvent.mouseLeave(wrap);
+    await waitFor(() => expect(screen.queryByRole('slider')).not.toBeInTheDocument());
   });
 
-  it('shows current volume percentage in popover', async () => {
-    const { user } = setup({ volume: 72 }, { volume: 72 });
-    await user.click(screen.getByTitle('Volume'));
+  it('shows current volume percentage in popover', () => {
+    const { container } = setup({ volume: 72 }, { volume: 72 });
+    const wrap = container.querySelector('[class*="volWrap"]') as HTMLElement;
+    fireEvent.mouseEnter(wrap);
     expect(screen.getByText('72')).toBeInTheDocument();
+  });
+
+  it('clicking the icon mutes when volume is non-zero', async () => {
+    setup({ volume: 60 }, { volume: 60 });
+    fireEvent.click(screen.getByTitle('Mute'));
+    await waitFor(() => expect(window.sonos.setGroupVolume).toHaveBeenCalledWith(0));
+  });
+
+  it('clicking the icon while muted restores the previous volume', async () => {
+    setup({ volume: 60 }, { volume: 60 });
+    fireEvent.click(screen.getByTitle('Mute'));
+    await waitFor(() => expect(window.sonos.setGroupVolume).toHaveBeenLastCalledWith(0));
+    fireEvent.click(screen.getByTitle('Unmute'));
+    await waitFor(() => expect(window.sonos.setGroupVolume).toHaveBeenLastCalledWith(60));
   });
 });
 

--- a/renderer/src/components/album/AlbumPanel.tsx
+++ b/renderer/src/components/album/AlbumPanel.tsx
@@ -5,6 +5,7 @@ import { useImage } from '../../hooks/useImage';
 import { useAlbumBrowse } from '../../hooks/useAlbumBrowse';
 import { usePlaylistBrowse } from '../../hooks/usePlaylistBrowse';
 import { useDominantColor } from '../../hooks/useDominantColor';
+import { useGeniusAlbumYear } from '../../hooks/useGeniusAlbumYear';
 import { artistQueryOptions } from '../../hooks/useArtistBrowse';
 import { resolveAlbumParams, isPlaylist, isProgram, getItemArt } from '../../lib/itemHelpers';
 import { createDragGhost } from '../../lib/dragHelpers';
@@ -53,6 +54,10 @@ export function AlbumPanel({ onAddToQueue }: Props) {
   const artUrl = data?.artUrl ?? (item ? getItemArt(item) : null);
   const cachedArt     = useImage(artUrl);
   const dominantColor = useDominantColor(cachedArt, { setGlobal: true });
+  const year = useGeniusAlbumYear(
+    isPlaylistOrProgram ? null : title,
+    isPlaylistOrProgram ? null : artist,
+  );
 
   useEffect(() => {
     setSelected(new Set());
@@ -120,7 +125,7 @@ export function AlbumPanel({ onAddToQueue }: Props) {
             )}
             {data && (
               <div className={styles.metaLine}>
-                {[data.totalTracks + ' songs', totalMins > 0 ? totalMins + ' min' : null].filter(Boolean).join(' \u2022 ')}
+                {[data.totalTracks + ' songs', totalMins > 0 ? totalMins + ' min' : null, year].filter(Boolean).join(' \u2022 ')}
               </div>
             )}
             <div className={styles.actions}>

--- a/renderer/src/components/queue/QueueSidebar.tsx
+++ b/renderer/src/components/queue/QueueSidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useImperativeHandle, useMemo, useRef, useState, Fragment, forwardRef } from 'react';
 import { useQueries } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
-import { applyReorderLocally } from '../../lib/queueHelpers';
+import { applyReorderLocally, expandToAlbumBlock } from '../../lib/queueHelpers';
 import { createDragGhost } from '../../lib/dragHelpers';
 import { getActiveProvider } from '../../providers';
 import { useAttribution } from '../../hooks/useAttribution';
@@ -78,6 +78,19 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
       enabled: !!(item.track.id && item.track.serviceId && item.track.accountId),
     })),
   });
+
+  // Album ids per item, resolved from useTrackDetails (the same data the queue row
+  // uses to render the album link) with the raw NormalizedTrack value as fallback.
+  // Sonos rarely embeds album info on raw queue rows so the resolved value is what
+  // the "Select album" button must match against.
+  const resolvedAlbumIds = useMemo<(string | null)[]>(
+    () =>
+      items.map((item, i) => {
+        const fromDetails = trackDetailsResults[i]?.data?.albumId;
+        return (fromDetails ?? item.track.albumId) || null;
+      }),
+    [items, trackDetailsResults],
+  );
 
   const [nowMs, setNowMs] = useState(0);
   useEffect(() => { setNowMs(Date.now()); }, [positionMs]);
@@ -346,14 +359,41 @@ onClick={handleContentClick}
       {selCount > 0 && (
         <div className={styles.selBar}>
           <span>{selCount} track{selCount !== 1 ? 's' : ''} selected</span>
-          <button className={styles.selDelBtn} onClick={async () => {
-            const indices = [...selected];
-            setItems(prev => prev.filter((_, i) => !selected.has(i)));
-            setSelected(new Set());
-            await getActiveProvider().removeFromQueue(indices).catch(() => { onRefresh(); onError('Failed to remove tracks'); });
-          }}>
-            Delete
-          </button>
+          <div className={styles.selActions}>
+            {selCount === 1 && (() => {
+              const anchor = [...selected][0];
+              const anchorTrack = items[anchor]?.track;
+              if (!anchorTrack) return null;
+              const block = expandToAlbumBlock(items.length, anchor, resolvedAlbumIds);
+              // Hide the button when there's nothing to expand to — keeps the bar
+              // from offering an action that would be a no-op (or that grabbed the
+              // whole queue back when this had an artist fallback).
+              if (block.size <= 1) return null;
+              const resolvedAlbumName =
+                trackDetailsResults[anchor]?.data?.albumName ?? anchorTrack.albumName;
+              const tooltip = `Expand to all ${block.size} tracks from ${resolvedAlbumName ?? 'this album'} in sequence`;
+              return (
+                <button
+                  className={styles.selExpandBtn}
+                  title={tooltip}
+                  onClick={() => {
+                    setSelected(block);
+                    lastSelected.current = anchor;
+                  }}
+                >
+                  Select album
+                </button>
+              );
+            })()}
+            <button className={styles.selDelBtn} onClick={async () => {
+              const indices = [...selected];
+              setItems(prev => prev.filter((_, i) => !selected.has(i)));
+              setSelected(new Set());
+              await getActiveProvider().removeFromQueue(indices).catch(() => { onRefresh(); onError('Failed to remove tracks'); });
+            }}>
+              Delete
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/renderer/src/components/queuedle/QueuedlePanel.tsx
+++ b/renderer/src/components/queuedle/QueuedlePanel.tsx
@@ -8,11 +8,16 @@ import {
   useGameRankings,
   useMyScore,
   useGameStats,
+  computeQueuedleRating,
+  getGameRankTier,
 } from '../../hooks/useDailyGame';
+import type { GameRanking } from '../../hooks/useDailyGame';
 import { QueuedleIntro } from './QueuedleIntro';
 import { QueuedleQuestionCard } from './QueuedleQuestionCard';
 import { QueuedleBonusScreen } from './QueuedleBonusScreen';
 import { QueuedleBonusResults } from './QueuedleBonusResults';
+import { QueuedleRankChange } from './QueuedleRankChange';
+import type { RankSnapshot } from './QueuedleRankChange';
 import { QueuedleSummary } from './QueuedleSummary';
 import { QueuedleCalendar } from './QueuedleCalendar';
 import { ScoreDistribution } from './ScoreDistribution';
@@ -20,7 +25,7 @@ import { MyScores } from './MyScores';
 import { getGameRankIcon } from '../../lib/gameRankAssets';
 import styles from '../../styles/Queuedle.module.css';
 
-type Phase = 'intro' | 'main' | 'bonus' | 'bonus-results' | 'summary';
+type Phase = 'intro' | 'main' | 'bonus' | 'bonus-results' | 'rank-change' | 'summary';
 type LeaderboardTab = 'today' | 'ranked';
 
 function londonDateToday(): string {
@@ -55,7 +60,9 @@ export function QueuedlePanel() {
 
   const leaderboard = useGameLeaderboard(gameId ?? undefined);
   const gameDates = useGameDates(displayName ?? undefined);
-  const rankings = useGameRankings(displayName ?? undefined, leaderboardTab === 'ranked');
+  // Always fetch rankings (not just when "Ranked" tab is open) so the post-game
+  // rank-change screen has the user's prior totals available.
+  const rankings = useGameRankings(displayName ?? undefined, true);
   const myScore = useMyScore(gameId, displayName);
   const gameStats = useGameStats(gameId);
   const alreadyPlayed = useMemo(() => {
@@ -96,6 +103,9 @@ export function QueuedlePanel() {
   const [localScore, setLocalScore] = useState<{ main: number; bonus: number } | null>(null);
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [devReplay, setDevReplay] = useState(false);
+  // Snapshot of the user's prior ranking row, captured once before today's submission.
+  // undefined = not captured yet; null = captured, user has no prior games.
+  const [beforeRanking, setBeforeRanking] = useState<GameRanking | null | undefined>(undefined);
 
   // Backfill localStorage from the cloud when the leaderboard shows the user has
   // played but the local key is missing (fresh install, cleared cache, new machine).
@@ -129,6 +139,48 @@ export function QueuedlePanel() {
     }
   }, [game, bonusSelections.length]);
 
+  // Capture the user's prior rankings row exactly once, before today's submission
+  // refetches the rankings query (which would include today's score and ruin the delta).
+  useEffect(() => {
+    if (!displayName) return;
+    if (beforeRanking !== undefined) return;
+    if (rankings.isLoading) return;
+    if (localScore !== null) return; // user already submitted; don't capture after the fact
+    const row = rankings.data?.find((r) => r.userName === displayName) ?? null;
+    setBeforeRanking(row);
+  }, [displayName, rankings.data, rankings.isLoading, beforeRanking, localScore]);
+
+  const afterRanking = useMemo<RankSnapshot | null>(() => {
+    if (!localScore || !game || beforeRanking === undefined) return null;
+    const todayScore = localScore.main + localScore.bonus;
+    const todayMax = game.questions.length * 2;
+    const totalScore = (beforeRanking?.totalScore ?? 0) + todayScore;
+    const possibleScore = (beforeRanking?.possibleScore ?? 0) + todayMax;
+    const gamesPlayed = (beforeRanking?.gamesPlayed ?? 0) + 1;
+    const averagePercent = possibleScore > 0 ? (totalScore / possibleScore) * 100 : 0;
+    const tier = getGameRankTier(averagePercent, gamesPlayed);
+    return {
+      rating: computeQueuedleRating(averagePercent),
+      averagePercent,
+      gamesPlayed,
+      tierKey: tier.key,
+      tierName: tier.name,
+      isProvisional: tier.isProvisional,
+    };
+  }, [localScore, game, beforeRanking]);
+
+  const beforeRankSnapshot = useMemo<RankSnapshot | null>(() => {
+    if (!beforeRanking) return null;
+    return {
+      rating: computeQueuedleRating(beforeRanking.averagePercent),
+      averagePercent: beforeRanking.averagePercent,
+      gamesPlayed: beforeRanking.gamesPlayed,
+      tierKey: beforeRanking.tierKey,
+      tierName: beforeRanking.tierName,
+      isProvisional: beforeRanking.isProvisional,
+    };
+  }, [beforeRanking]);
+
   function resetGameState() {
     setPhase('intro');
     setCurrentIdx(0);
@@ -138,6 +190,7 @@ export function QueuedlePanel() {
     setBonusSelections([]);
     setLocalScore(null);
     setDevReplay(false);
+    setBeforeRanking(undefined);
   }
 
   function handleDevPlayAgain() {
@@ -524,7 +577,7 @@ export function QueuedlePanel() {
         {headerActions}
       </div>
       <div className={styles.body}>
-        {phase !== 'intro' && phase !== 'summary' && phase !== 'bonus-results' && (
+        {phase !== 'intro' && phase !== 'summary' && phase !== 'bonus-results' && phase !== 'rank-change' && (
           <div className={styles.progress}>
             {pips.map((cls, i) => (
               <div key={i} className={`${styles.pip}${cls ? ' ' + cls : ''}`} />
@@ -559,6 +612,19 @@ export function QueuedlePanel() {
           <QueuedleBonusResults
             winningItems={winningItems}
             bonusGuesses={bonusGuesses}
+            onContinue={() => {
+              // Skip the rank-change beat for dev replays (no real submission) and
+              // when we couldn't compute an "after" snapshot (e.g. no displayName).
+              if (devReplay || !afterRanking) setPhase('summary');
+              else setPhase('rank-change');
+            }}
+          />
+        )}
+
+        {phase === 'rank-change' && afterRanking && (
+          <QueuedleRankChange
+            before={beforeRankSnapshot}
+            after={afterRanking}
             onContinue={() => setPhase('summary')}
           />
         )}

--- a/renderer/src/components/queuedle/QueuedleRankChange.tsx
+++ b/renderer/src/components/queuedle/QueuedleRankChange.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from 'react';
+import { getGameRankIcon } from '../../lib/gameRankAssets';
+import type { GameRankTierKey } from '../../hooks/useDailyGame';
+import styles from '../../styles/Queuedle.module.css';
+
+export interface RankSnapshot {
+  rating: number;
+  averagePercent: number;
+  gamesPlayed: number;
+  tierKey: GameRankTierKey;
+  tierName: string;
+  isProvisional: boolean;
+}
+
+interface Props {
+  before: RankSnapshot | null;
+  after: RankSnapshot;
+  onContinue: () => void;
+}
+
+const ANIM_MS = 1200;
+
+function useTween(from: number, to: number, durationMs: number) {
+  const [value, setValue] = useState(from);
+  const startRef = useRef<number | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    startRef.current = null;
+    const tick = (now: number) => {
+      if (startRef.current === null) startRef.current = now;
+      const t = Math.min(1, (now - startRef.current) / durationMs);
+      const eased = 1 - Math.pow(1 - t, 3);
+      setValue(Math.round(from + (to - from) * eased));
+      if (t < 1) rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [from, to, durationMs]);
+
+  return value;
+}
+
+export function QueuedleRankChange({ before, after, onContinue }: Props) {
+  const fromRating = before?.rating ?? after.rating;
+  const display = useTween(fromRating, after.rating, ANIM_MS);
+  const delta = before ? after.rating - before.rating : 0;
+  const tierChanged = !!before && before.tierKey !== after.tierKey;
+  const tierIcon = getGameRankIcon(after.tierKey);
+  const prevTierIcon = before ? getGameRankIcon(before.tierKey) : null;
+
+  const deltaLabel = delta > 0 ? `+${delta}` : `${delta}`;
+  const deltaClass =
+    delta > 0
+      ? styles.rankDeltaUp
+      : delta < 0
+        ? styles.rankDeltaDown
+        : styles.rankDeltaFlat;
+
+  return (
+    <div className={styles.rankChangeWrap}>
+      <h2 className={styles.rankChangeTitle}>
+        {before ? 'Rank update' : 'Welcome to the ranks'}
+      </h2>
+
+      <div className={styles.rankChangeBadgeRow}>
+        {tierChanged && prevTierIcon && (
+          <div className={styles.rankBadgePrev}>
+            <img src={prevTierIcon} alt="" className={styles.rankBadgeImg} />
+          </div>
+        )}
+        {tierChanged && prevTierIcon && (
+          <div className={styles.rankBadgeArrow}>→</div>
+        )}
+        <div
+          className={`${styles.rankBadgeCurrent}${tierChanged ? ' ' + styles.rankBadgePulse : ''}`}
+        >
+          {tierIcon ? (
+            <img src={tierIcon} alt="" className={styles.rankBadgeImg} />
+          ) : (
+            <div className={styles.rankBadgePlaceholder} />
+          )}
+        </div>
+      </div>
+
+      <div className={styles.rankTierName}>{after.tierName}</div>
+
+      <div className={styles.rankRatingRow}>
+        <span className={styles.rankRatingNumber}>{display}</span>
+        {before && !after.isProvisional && !before.isProvisional && delta !== 0 && (
+          <span className={`${styles.rankDeltaChip} ${deltaClass}`}>{deltaLabel}</span>
+        )}
+      </div>
+
+      {after.isProvisional && (
+        <div className={styles.rankProvisional}>
+          Provisional · play {Math.max(0, 3 - after.gamesPlayed)} more
+          {Math.max(0, 3 - after.gamesPlayed) === 1 ? ' game' : ' games'} to lock in a tier
+        </div>
+      )}
+
+      <div className={styles.submitRow}>
+        <button className={styles.nextBtn} onClick={onContinue}>
+          Continue →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/renderer/src/components/queuedle/__tests__/QueuedlePanel.test.tsx
+++ b/renderer/src/components/queuedle/__tests__/QueuedlePanel.test.tsx
@@ -21,6 +21,16 @@ vi.mock('@/hooks/useDailyGame', () => ({
   useGameRankings: (userName?: string | null, enabled?: boolean) => mockUseGameRankings(userName, enabled),
   useMyScore: (gameId: string | null, userName: string | null | undefined) => mockUseMyScore(gameId, userName),
   useGameStats: (gameId: string | null) => mockUseGameStats(gameId),
+  computeQueuedleRating: (averagePercent: number) =>
+    Math.round(Math.max(0, Math.min(100, averagePercent)) * 30),
+  getGameRankTier: (averagePercent: number, gamesPlayed: number) => {
+    if (gamesPlayed < 3) return { key: 'provisional', name: 'Provisional', isProvisional: true };
+    if (averagePercent >= 85) return { key: 'playlist-prophet', name: 'Playlist Prophet', isProvisional: false };
+    if (averagePercent >= 70) return { key: 'algorithm-whisperer', name: 'Algorithm Whisperer', isProvisional: false };
+    if (averagePercent >= 55) return { key: 'aux-cable-apprentice', name: 'Aux Cable Apprentice', isProvisional: false };
+    if (averagePercent >= 40) return { key: 'background-bopper', name: 'Background Bopper', isProvisional: false };
+    return { key: 'skip-button-survivor', name: 'Skip Button Survivor', isProvisional: false };
+  },
 }));
 
 vi.mock('../QueuedleIntro', () => ({
@@ -68,6 +78,14 @@ vi.mock('../QueuedleBonusResults', () => ({
     <div>
       Bonus results
       <button onClick={onContinue}>See Score</button>
+    </div>
+  ),
+}));
+vi.mock('../QueuedleRankChange', () => ({
+  QueuedleRankChange: ({ onContinue }: { onContinue: () => void }) => (
+    <div>
+      Rank change
+      <button onClick={onContinue}>Continue Rank</button>
     </div>
   ),
 }));
@@ -280,6 +298,7 @@ describe('QueuedlePanel', () => {
     await user.click(screen.getByText('Submit Bonus'));
     await waitFor(() => screen.getByText('Bonus results'));
     await user.click(screen.getByText('See Score'));
+    await user.click(screen.getByText('Continue Rank'));
     expect(screen.getByText('Score: 2')).toBeInTheDocument();
   });
 
@@ -294,6 +313,7 @@ describe('QueuedlePanel', () => {
     await user.click(screen.getByText('Submit Bonus'));
     await waitFor(() => screen.getByText('Bonus results'));
     await user.click(screen.getByText('See Score'));
+    await user.click(screen.getByText('Continue Rank'));
     expect(screen.getByText('Score: 2')).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Ranked' })).toBeInTheDocument();
   });
@@ -309,6 +329,7 @@ describe('QueuedlePanel', () => {
     await user.click(screen.getByText('Submit Bonus'));
     await waitFor(() => screen.getByText('Bonus results'));
     await user.click(screen.getByText('See Score'));
+    await user.click(screen.getByText('Continue Rank'));
     expect(screen.getByText('Score: 1')).toBeInTheDocument();
   });
 
@@ -324,6 +345,7 @@ describe('QueuedlePanel', () => {
     await user.click(screen.getByText('Submit Bonus'));
     await waitFor(() => screen.getByText('Bonus results'));
     await user.click(screen.getByText('See Score'));
+    await user.click(screen.getByText('Continue Rank'));
     // main=1 (picked left, winner is left), bonus=0 (bonusSelections all null, topQueuer is 'alice')
     expect(screen.getByText('Score: 1')).toBeInTheDocument();
   });
@@ -349,6 +371,7 @@ describe('QueuedlePanel', () => {
     await flushPromises();
     expect(screen.getByText('Bonus results')).toBeInTheDocument();
     await user.click(screen.getByText('See Score'));
+    await user.click(screen.getByText('Continue Rank'));
     expect(screen.getByText('Score: 1')).toBeInTheDocument();
   });
 
@@ -406,7 +429,9 @@ describe('QueuedlePanel', () => {
     localStorage.setItem('queuedle-played:2024-01-01', JSON.stringify({ mainScore: 2, bonusScore: 1 }));
     render(<QueuedlePanel />);
     await waitFor(() => expect(screen.getByRole('tab', { name: 'Ranked' })).toBeInTheDocument());
-    await waitFor(() => expect(mockUseGameRankings).toHaveBeenLastCalledWith('TestUser', false));
+    // Rankings are now always enabled so the post-game rank-change screen has the
+    // user's prior totals available without a tab switch.
+    await waitFor(() => expect(mockUseGameRankings).toHaveBeenLastCalledWith('TestUser', true));
   });
 
   it('clicking Ranked shows average total rankings', async () => {

--- a/renderer/src/hooks/useDailyGame.ts
+++ b/renderer/src/hooks/useDailyGame.ts
@@ -7,10 +7,18 @@ export interface GameRanking {
   averageMain: number;
   averageBonus: number;
   averagePercent: number;
+  totalScore: number;
+  possibleScore: number;
   bestTotal: number;
   tierKey: GameRankTierKey;
   tierName: string;
   isProvisional: boolean;
+}
+
+// 0-100% mapped to a 0-3000 SR-like rating, used by the post-game rank-change screen.
+export function computeQueuedleRating(averagePercent: number): number {
+  if (!Number.isFinite(averagePercent)) return 0;
+  return Math.round(Math.max(0, Math.min(100, averagePercent)) * 30);
 }
 
 interface RankingAccumulator {
@@ -124,6 +132,8 @@ export function calculateGameRankings(sources: GameRankingSource[]): GameRanking
         averageMain: entry.mainScore / entry.gamesPlayed,
         averageBonus: entry.bonusScore / entry.gamesPlayed,
         averagePercent,
+        totalScore: entry.totalScore,
+        possibleScore: entry.possibleScore,
         bestTotal: entry.bestTotal,
         tierKey: tier.key,
         tierName: tier.name,

--- a/renderer/src/hooks/useGeniusAlbumYear.ts
+++ b/renderer/src/hooks/useGeniusAlbumYear.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+
+export function geniusAlbumYearQueryOptions(
+  albumName: string | null | undefined,
+  artistName: string | null | undefined,
+) {
+  return {
+    queryKey: ['genius-album-year', albumName, artistName] as const,
+    queryFn: (): Promise<number | null> =>
+      window.sonos.geniusAlbumYear(albumName!, artistName!),
+    staleTime: Infinity,
+    retry: false,
+    enabled: !!albumName && !!artistName,
+  };
+}
+
+export function useGeniusAlbumYear(
+  albumName: string | null | undefined,
+  artistName: string | null | undefined,
+) {
+  const { data } = useQuery(geniusAlbumYearQueryOptions(albumName, artistName));
+  return data ?? null;
+}

--- a/renderer/src/hooks/useNowPlaying.ts
+++ b/renderer/src/hooks/useNowPlaying.ts
@@ -46,6 +46,13 @@ export function useNowPlaying(playback: PlaybackState) {
     resource: { type: 'ALBUM', id: { objectId: albumId, serviceId: svcId, accountId: accId } },
   } as SonosItem : null;
 
+  const artistId = td?.artistId;
+  const artistItem: SonosItem | null = artistId ? {
+    title: displayArtist ?? '',
+    type: 'ARTIST',
+    resource: { type: 'ARTIST', id: { objectId: artistId, serviceId: svcId, accountId: accId } },
+  } as SonosItem : null;
+
   return {
     // Display values
     displayTrack, displayArtist, albumName, albumId,
@@ -61,6 +68,7 @@ export function useNowPlaying(playback: PlaybackState) {
     artUrlRaw: td?.artUrl ?? artUrl ?? null,
     // Derived
     albumItem,
+    artistItem,
     prefetchAlbum,
   };
 }

--- a/renderer/src/lib/__tests__/queueHelpers.test.ts
+++ b/renderer/src/lib/__tests__/queueHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyReorderLocally } from '../queueHelpers';
+import { applyReorderLocally, expandToAlbumBlock } from '../queueHelpers';
 
 // Using plain strings — applyReorderLocally is generic, no QueueItem needed here.
 const items = ['A', 'B', 'C', 'D', 'E'];
@@ -73,5 +73,54 @@ describe('applyReorderLocally', () => {
 
   it('toIndex at the very end equals length', () => {
     expect(applyReorderLocally(['A', 'B', 'C'], [0], 3)).toEqual(['B', 'C', 'A']);
+  });
+});
+
+describe('expandToAlbumBlock', () => {
+  it('selects a contiguous run of tracks sharing an albumId', () => {
+    const albumIds = ['A', 'A', 'A', 'B'];
+    expect([...expandToAlbumBlock(albumIds.length, 1, albumIds)].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+  });
+
+  it('stops at the boundary of a different album', () => {
+    const albumIds = ['A', 'B', 'B', 'A'];
+    expect([...expandToAlbumBlock(albumIds.length, 1, albumIds)].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it('returns just the anchor when anchor has no albumId (no artist fallback)', () => {
+    const albumIds = [null, null, null];
+    expect([...expandToAlbumBlock(albumIds.length, 0, albumIds)]).toEqual([0]);
+  });
+
+  it('returns just the anchor when an empty-string albumId is passed', () => {
+    const albumIds = ['', '', ''];
+    expect([...expandToAlbumBlock(albumIds.length, 0, albumIds)]).toEqual([0]);
+  });
+
+  it('returns just the anchor when neighbours have different albums', () => {
+    const albumIds = ['A', 'B', 'C'];
+    expect([...expandToAlbumBlock(albumIds.length, 1, albumIds)]).toEqual([1]);
+  });
+
+  it('handles anchor at the start of the list', () => {
+    const albumIds = ['A', 'A', 'B'];
+    expect([...expandToAlbumBlock(albumIds.length, 0, albumIds)].sort((a, b) => a - b)).toEqual([0, 1]);
+  });
+
+  it('handles anchor at the end of the list', () => {
+    const albumIds = ['B', 'A', 'A'];
+    expect([...expandToAlbumBlock(albumIds.length, 2, albumIds)].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it('returns just the anchor when anchor is out of bounds', () => {
+    const albumIds = ['A'];
+    expect([...expandToAlbumBlock(albumIds.length, 5, albumIds)]).toEqual([5]);
+  });
+
+  it('does not run away when missing-albumId neighbours sit between two same-album items', () => {
+    // Regression: previous artist-fallback code could grab unmatched neighbours.
+    // With a strict same-album-id match, a null between two A's stops expansion.
+    const albumIds = ['A', null, 'A'];
+    expect([...expandToAlbumBlock(albumIds.length, 0, albumIds)]).toEqual([0]);
   });
 });

--- a/renderer/src/lib/queueHelpers.ts
+++ b/renderer/src/lib/queueHelpers.ts
@@ -6,3 +6,33 @@ export function applyReorderLocally<T>(items: T[], fromIndices: number[], toInde
   const movers = [...fromIndices].sort((a, b) => a - b).map(i => items[i]);
   return [...remaining.slice(0, insertAt), ...movers, ...remaining.slice(insertAt)];
 }
+
+// Returns the indices of the contiguous run of queue items that share the anchor's
+// album id. Always includes the anchor. If the anchor has no resolved album id, or
+// no adjacent neighbour matches, returns just the anchor (no artist fallback —
+// matching by artist alone tends to grab the entire queue when every track has the
+// same artist or empty/unresolved artist).
+//
+// `albumIds` is aligned to the queue items. Callers must supply the merged album id
+// (e.g. NormalizedTrack values overlaid with whatever `useTrackDetails` resolved)
+// because Sonos doesn't reliably embed album info on raw queue rows.
+export function expandToAlbumBlock(
+  itemCount: number,
+  anchor: number,
+  albumIds: (string | null)[],
+): Set<number> {
+  if (anchor < 0 || anchor >= itemCount) return new Set([anchor]);
+  const anchorAlbum = albumIds[anchor];
+  if (!anchorAlbum) return new Set([anchor]);
+
+  const result = new Set<number>([anchor]);
+  for (let i = anchor - 1; i >= 0; i--) {
+    if (albumIds[i] !== anchorAlbum) break;
+    result.add(i);
+  }
+  for (let i = anchor + 1; i < itemCount; i++) {
+    if (albumIds[i] !== anchorAlbum) break;
+    result.add(i);
+  }
+  return result;
+}

--- a/renderer/src/styles/App.module.css
+++ b/renderer/src/styles/App.module.css
@@ -46,3 +46,16 @@
   from { opacity: 0; transform: translateX(-50%) translateY(8px); }
   to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
+
+.entraSigningIn {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-2);
+  font-size: 14px;
+}

--- a/renderer/src/styles/DisplayNameModal.module.css
+++ b/renderer/src/styles/DisplayNameModal.module.css
@@ -79,3 +79,10 @@
   opacity: 0.4;
   cursor: default;
 }
+
+.error {
+  font-size: 12px;
+  color: #f87171;
+  text-align: left;
+  margin: -4px 0;
+}

--- a/renderer/src/styles/PlayerBar.module.css
+++ b/renderer/src/styles/PlayerBar.module.css
@@ -72,12 +72,47 @@
   flex-shrink: 0;
   overflow: hidden;
 }
+.trackLine {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  min-width: 0;
+}
 .trackName {
   font-size: 13px;
   font-weight: 600;
   color: #fff;
   white-space: nowrap;
   overflow: hidden;
+  min-width: 0;
+}
+.trackSep {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  flex-shrink: 0;
+  white-space: pre;
+}
+.trackArtist {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+button.trackArtist {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color 0.12s;
+}
+button.trackArtist:hover {
+  text-decoration: underline;
 }
 
 @keyframes tt-scroll {
@@ -254,6 +289,16 @@
   animation: volFadeIn 0.12s ease;
 }
 
+/* Invisible bridge so hover stays continuous between icon and popover */
+.volPopover::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  height: 8px;
+}
+
 @keyframes volFadeIn {
   from {
     opacity: 0;
@@ -299,4 +344,25 @@
 }
 .volSliderV:hover {
   background: rgba(255, 255, 255, 0.3);
+}
+
+.volStep {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.12s, background 0.12s;
+}
+.volStep:hover:not(:disabled) {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+}
+.volStep:disabled {
+  opacity: 0.3;
+  cursor: default;
 }

--- a/renderer/src/styles/ProfilePanel.module.css
+++ b/renderer/src/styles/ProfilePanel.module.css
@@ -140,6 +140,73 @@
 }
 .signOutInline:hover { color: rgba(255, 80, 80, 1); }
 
+.changeNameInline {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.12s;
+}
+.changeNameInline:hover { color: var(--text-2); }
+
+.renameForm {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-bottom: 20px;
+}
+
+.renameInput {
+  background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: var(--r-md);
+  color: var(--text);
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -1px;
+  padding: 4px 12px;
+  outline: none;
+  width: 260px;
+}
+.renameInput:focus { border-color: rgba(255,255,255,0.35); }
+
+.renameBtn {
+  background: rgba(255,255,255,0.12);
+  border: 1px solid var(--border-2);
+  border-radius: var(--r-md);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.renameBtn:hover:not(:disabled) { background: rgba(255,255,255,0.2); }
+.renameBtn:disabled { opacity: 0.4; cursor: default; }
+
+.renameCancelBtn {
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font-size: 13px;
+  font-family: inherit;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+.renameCancelBtn:hover { color: var(--text-2); }
+
+.renameError {
+  width: 100%;
+  font-size: 12px;
+  color: #f87171;
+}
+
 /* ── Sections ────────────────────────────────────────────────────────────── */
 
 .section {

--- a/renderer/src/styles/QueueSidebar.module.css
+++ b/renderer/src/styles/QueueSidebar.module.css
@@ -337,6 +337,12 @@
 
 .selBar span { font-size: 12px; color: var(--text-2); }
 
+.selActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .selDelBtn {
   background: none;
   border: 1px solid rgba(255,80,80,0.4);
@@ -349,6 +355,20 @@
   background: rgba(255,60,60,0.15);
   border-color: rgba(255,80,80,0.7);
   color: #ff6464;
+}
+
+.selExpandBtn {
+  background: none;
+  border: 1px solid rgba(255,255,255,0.2);
+  color: var(--text-2);
+  font-size: 11px; font-weight: 600; font-family: inherit;
+  padding: 4px 12px; border-radius: 12px;
+  cursor: pointer; transition: all 0.15s;
+}
+.selExpandBtn:hover {
+  background: rgba(255,255,255,0.08);
+  border-color: rgba(255,255,255,0.35);
+  color: var(--text);
 }
 
 /* ── Misc ── */

--- a/renderer/src/styles/Queuedle.module.css
+++ b/renderer/src/styles/Queuedle.module.css
@@ -1247,3 +1247,149 @@
   background: var(--bg-2);
   color: var(--text);
 }
+
+/* ── Rank change screen ── */
+.rankChangeWrap {
+  max-width: 480px;
+  margin: 32px auto 0;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.rankChangeTitle {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 24px;
+  letter-spacing: -0.01em;
+}
+
+.rankChangeBadgeRow {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.rankBadgePrev,
+.rankBadgeCurrent {
+  width: 96px;
+  height: 96px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.rankBadgePrev {
+  opacity: 0.45;
+  transform: scale(0.85);
+}
+
+.rankBadgeImg {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.rankBadgePlaceholder {
+  width: 60%;
+  height: 60%;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.rankBadgeArrow {
+  font-size: 20px;
+  color: var(--text-3);
+}
+
+@keyframes rankBadgePulse {
+  0% {
+    transform: scale(0.85);
+    box-shadow: 0 0 0 0 rgba(29, 185, 84, 0.5);
+  }
+  50% {
+    transform: scale(1.06);
+    box-shadow: 0 0 0 16px rgba(29, 185, 84, 0);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(29, 185, 84, 0);
+  }
+}
+
+.rankBadgePulse {
+  animation: rankBadgePulse 1.2s ease-out;
+}
+
+.rankTierName {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 18px;
+  letter-spacing: 0.02em;
+}
+
+.rankRatingRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 14px;
+  margin-bottom: 12px;
+}
+
+.rankRatingNumber {
+  font-size: 56px;
+  font-weight: 800;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.rankDeltaChip {
+  font-size: 14px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  padding: 4px 10px;
+  border-radius: 999px;
+  animation: rankDeltaIn 0.4s ease-out both;
+}
+
+@keyframes rankDeltaIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.rankDeltaUp {
+  color: #1db954;
+  background: rgba(29, 185, 84, 0.15);
+}
+
+.rankDeltaDown {
+  color: #ff6464;
+  background: rgba(255, 100, 100, 0.15);
+}
+
+.rankDeltaFlat {
+  color: var(--text-3);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.rankProvisional {
+  font-size: 12px;
+  color: var(--text-3);
+  margin-top: 4px;
+  margin-bottom: 8px;
+}

--- a/renderer/src/test/setup.ts
+++ b/renderer/src/test/setup.ts
@@ -87,5 +87,10 @@ Object.defineProperty(window, 'sonos', {
     fetchUsers:           vi.fn(() => Promise.resolve([])),
     fetchUserProfile:     vi.fn(() => Promise.resolve(null)),
     uploadProfileImage:   vi.fn(pending),
+    getEntraUser:         vi.fn(() => Promise.resolve(null)),
+    entraSignOut:         vi.fn(() => Promise.resolve()),
+    entraReLogin:         vi.fn(() => Promise.resolve()),
+    onEntraReady:         vi.fn(noop),
+    renameUser:           vi.fn(() => Promise.resolve({ ok: true })),
   },
 });

--- a/renderer/src/test/setup.ts
+++ b/renderer/src/test/setup.ts
@@ -64,6 +64,7 @@ Object.defineProperty(window, 'sonos', {
     fetchRecentlyPlayed: vi.fn(() => Promise.resolve(null)),
     geniusDescription:  vi.fn(() => Promise.resolve(null)),
     geniusArtist:       vi.fn(() => Promise.resolve(null)),
+    geniusAlbumYear:    vi.fn(() => Promise.resolve(null)),
     trackEvent:         vi.fn(() => Promise.resolve()),
     minimizeWindow:     vi.fn(() => Promise.resolve()),
     maximizeWindow:     vi.fn(() => Promise.resolve()),

--- a/renderer/src/types/globals.d.ts
+++ b/renderer/src/types/globals.d.ts
@@ -229,6 +229,12 @@ interface RecentlyPlayedData {
   availableUsers?: string[];
 }
 
+interface EntraUser {
+  oid: string;
+  name: string;
+  email: string;
+}
+
 interface UserProfile {
   id: string;
   imageUrl?: string | null;
@@ -307,7 +313,7 @@ interface SonosPreload {
   closeMiniPlayer: () => Promise<void>;
   // Attribution / office presence
   getDisplayName: () => Promise<string | null>;
-  setDisplayName: (name: string) => Promise<void>;
+  setDisplayName: (name: string) => Promise<{ error: string } | null>;
   getQueueDockedWidth: () => Promise<number>;
   setQueueDockedWidth: (width: number) => Promise<void>;
   publishQueued: (item: {
@@ -363,6 +369,11 @@ interface SonosPreload {
   fetchUsers: () => Promise<UserSummary[]>;
   fetchUserProfile: (userName: string) => Promise<UserProfile | null>;
   uploadProfileImage: (userName: string, data: ArrayBuffer, mimeType: string) => Promise<{ imageUrl: string } | { error: string }>;
+  getEntraUser: () => Promise<EntraUser | null>;
+  entraSignOut: () => Promise<void>;
+  entraReLogin: () => Promise<void>;
+  onEntraReady: (cb: (user: EntraUser) => void) => Unsubscribe;
+  renameUser: (oldName: string, newName: string) => Promise<{ ok?: boolean; error?: string }>;
 }
 
 interface Window {

--- a/renderer/src/types/globals.d.ts
+++ b/renderer/src/types/globals.d.ts
@@ -339,6 +339,7 @@ interface SonosPreload {
   onAttributionEvent: (cb: (event: AttributionEvent) => void) => Unsubscribe;
   geniusDescription: (trackName: string, artistName: string) => Promise<GeniusDomNode | null>;
   geniusArtist: (artistName: string, trackHint?: string) => Promise<GeniusArtistInfo | null>;
+  geniusAlbumYear: (albumName: string, artistName: string) => Promise<number | null>;
   /** Fire-and-forget telemetry event routed through the main process. No-op when App Insights is not configured. */
   trackEvent: (name: string, properties?: Record<string, string>) => Promise<void>;
   minimizeWindow:    () => Promise<void>;

--- a/server/src/functions/claim-name.ts
+++ b/server/src/functions/claim-name.ts
@@ -1,0 +1,89 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { CosmosClient } from '@azure/cosmos';
+
+// POST /api/profile/claim
+// Body: { oid: string, displayName: string }
+//
+// Adds entraOid to the profiles document for displayName, enforcing 1:1 ownership.
+// Also releases any previous claim this OID held on a different display name.
+//
+// Returns:
+//   200 { ok: true }             — claimed or already owned by this OID
+//   409 { error: 'taken' }       — another OID already owns this display name
+//   400                          — missing fields
+//   500                          — Cosmos error
+
+export async function claimNameHandler(
+  request: HttpRequest,
+  context: InvocationContext,
+): Promise<HttpResponseInit> {
+  const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+
+  let body: { oid?: string; displayName?: string };
+  try {
+    body = (await request.json()) as { oid?: string; displayName?: string };
+  } catch {
+    return { status: 400, jsonBody: { error: 'Invalid JSON' }, headers: corsHeaders };
+  }
+
+  const { oid, displayName } = body;
+  if (!oid || !displayName) {
+    return { status: 400, jsonBody: { error: 'oid and displayName required' }, headers: corsHeaders };
+  }
+
+  const connStr = process.env['COSMOS_CONNECTION_STRING'];
+  const dbName  = process.env['COSMOS_DATABASE'] ?? 'truetunes';
+  if (!connStr) return { status: 500, jsonBody: { error: 'Cosmos not configured' }, headers: corsHeaders };
+
+  const container = new CosmosClient(connStr).database(dbName).container('profiles');
+
+  try {
+    // 1. Check if the requested display name is already claimed by someone else.
+    let existing: Record<string, unknown> | undefined;
+    try {
+      const { resource } = await container.item(displayName, displayName).read<Record<string, unknown>>();
+      existing = resource;
+    } catch (err: unknown) {
+      if ((err as { code?: number }).code !== 404) throw err;
+    }
+
+    if (existing?.entraOid && existing.entraOid !== oid) {
+      // Owned by a different Entra user — reject.
+      return { status: 409, jsonBody: { error: 'taken' }, headers: corsHeaders };
+    }
+
+    // 2. Release any previous claim this OID held on a different display name.
+    //    Cross-partition query is fine for a small user base.
+    const { resources: prevClaims } = await container.items
+      .query<Record<string, unknown>>({
+        query: 'SELECT * FROM c WHERE c.entraOid = @oid AND c.id != @displayName',
+        parameters: [
+          { name: '@oid', value: oid },
+          { name: '@displayName', value: displayName },
+        ],
+      })
+      .fetchAll();
+
+    for (const prev of prevClaims) {
+      const { entraOid: _removed, ...rest } = prev as Record<string, unknown> & { entraOid?: unknown };
+      await container.items.upsert(rest);
+    }
+
+    // 3. Upsert the profile with this OID as owner.
+    const upserted = { ...(existing ?? {}), id: displayName, entraOid: oid };
+    await container.items.upsert(upserted);
+
+    context.log(`[claim-name] ${displayName} claimed by oid=${oid}`);
+    return { status: 200, jsonBody: { ok: true }, headers: corsHeaders };
+  } catch (err) {
+    context.error('[claim-name] failed:', err);
+    return { status: 500, jsonBody: { error: String(err) }, headers: corsHeaders };
+  }
+}
+
+app.http('claim-name', {
+  methods: ['POST'],
+  route: 'profile/claim',
+  authLevel: 'anonymous',
+  handler: claimNameHandler,
+});

--- a/server/src/functions/profile-by-oid.ts
+++ b/server/src/functions/profile-by-oid.ts
@@ -1,0 +1,54 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { CosmosClient } from '@azure/cosmos';
+
+// GET /api/profile/lookup?oid=<entraOid>
+//
+// Returns the display name (profile id) associated with this Entra OID, if any.
+//
+// Returns:
+//   200 { displayName: string }   — profile found
+//   404 {}                        — no profile for this OID
+//   400                           — missing oid
+//   500                           — Cosmos error
+
+export async function profileByOidHandler(
+  request: HttpRequest,
+  context: InvocationContext,
+): Promise<HttpResponseInit> {
+  const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+
+  const oid = request.query.get('oid');
+  if (!oid) return { status: 400, jsonBody: { error: 'oid required' }, headers: corsHeaders };
+
+  const connStr = process.env['COSMOS_CONNECTION_STRING'];
+  const dbName  = process.env['COSMOS_DATABASE'] ?? 'truetunes';
+  if (!connStr) return { status: 500, jsonBody: { error: 'Cosmos not configured' }, headers: corsHeaders };
+
+  const container = new CosmosClient(connStr).database(dbName).container('profiles');
+
+  try {
+    const { resources } = await container.items
+      .query<{ id: string }>({
+        query: 'SELECT c.id FROM c WHERE c.entraOid = @oid OFFSET 0 LIMIT 1',
+        parameters: [{ name: '@oid', value: oid }],
+      })
+      .fetchAll();
+
+    if (resources.length === 0) {
+      return { status: 404, jsonBody: {}, headers: corsHeaders };
+    }
+
+    context.log(`[profile-by-oid] oid=${oid} → ${resources[0].id}`);
+    return { status: 200, jsonBody: { displayName: resources[0].id }, headers: corsHeaders };
+  } catch (err) {
+    context.error('[profile-by-oid] failed:', err);
+    return { status: 500, jsonBody: { error: String(err) }, headers: corsHeaders };
+  }
+}
+
+app.http('profile-by-oid', {
+  methods: ['GET'],
+  route: 'profile/lookup',
+  authLevel: 'anonymous',
+  handler: profileByOidHandler,
+});

--- a/server/src/functions/rename-user.ts
+++ b/server/src/functions/rename-user.ts
@@ -1,0 +1,159 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import { CosmosClient } from '@azure/cosmos';
+
+// POST /api/profile/rename
+// Body: { oid: string, oldName: string, newName: string }
+//
+// Migrates all Cosmos data from oldName → newName:
+//   events    — re-partitions documents (userId is partition key)
+//   scores    — rewrites composite id (gameId|userName)
+//   profiles  — moves the document to new id
+//   playlists — updates owner, members[], and track addedBy fields
+//
+// Returns:
+//   200 { ok: true, counts: { events, scores, playlists } }
+//   403 { error: 'not-owner' }  — OID doesn't own oldName
+//   409 { error: 'taken' }      — newName already owned by a different OID
+//   400                         — missing fields
+//   500                         — Cosmos error
+
+export async function renameUserHandler(
+  request: HttpRequest,
+  context: InvocationContext,
+): Promise<HttpResponseInit> {
+  const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+
+  let body: { oid?: string; oldName?: string; newName?: string };
+  try {
+    body = (await request.json()) as { oid?: string; oldName?: string; newName?: string };
+  } catch {
+    return { status: 400, jsonBody: { error: 'Invalid JSON' }, headers: corsHeaders };
+  }
+
+  const { oid, oldName, newName } = body;
+  if (!oid || !oldName || !newName) {
+    return { status: 400, jsonBody: { error: 'oid, oldName, and newName required' }, headers: corsHeaders };
+  }
+  if (oldName === newName) {
+    return { status: 200, jsonBody: { ok: true, counts: { events: 0, scores: 0, playlists: 0 } }, headers: corsHeaders };
+  }
+
+  const connStr = process.env['COSMOS_CONNECTION_STRING'];
+  const dbName  = process.env['COSMOS_DATABASE'] ?? 'truetunes';
+  if (!connStr) return { status: 500, jsonBody: { error: 'Cosmos not configured' }, headers: corsHeaders };
+
+  const db = new CosmosClient(connStr).database(dbName);
+
+  try {
+    const profiles  = db.container('profiles');
+    const events    = db.container('events');
+    const scores    = db.container('scores');
+    const playlists = db.container('playlists');
+
+    // 1. Verify OID owns oldName.
+    let oldProfile: Record<string, unknown> | undefined;
+    try {
+      const { resource } = await profiles.item(oldName, oldName).read<Record<string, unknown>>();
+      oldProfile = resource;
+    } catch (err: unknown) {
+      if ((err as { code?: number }).code !== 404) throw err;
+    }
+    if (!oldProfile?.entraOid || oldProfile.entraOid !== oid) {
+      return { status: 403, jsonBody: { error: 'not-owner' }, headers: corsHeaders };
+    }
+
+    // 2. Check newName isn't taken by a different OID.
+    let newProfile: Record<string, unknown> | undefined;
+    try {
+      const { resource } = await profiles.item(newName, newName).read<Record<string, unknown>>();
+      newProfile = resource;
+    } catch (err: unknown) {
+      if ((err as { code?: number }).code !== 404) throw err;
+    }
+    if (newProfile?.entraOid && newProfile.entraOid !== oid) {
+      return { status: 409, jsonBody: { error: 'taken' }, headers: corsHeaders };
+    }
+
+    // 3. Migrate events.
+    // Partition key is userId, so rename = insert into new partition + delete from old.
+    const { resources: eventDocs } = await events.items
+      .query<Record<string, unknown>>({
+        query: 'SELECT * FROM c WHERE c.userId = @oldName',
+        parameters: [{ name: '@oldName', value: oldName }],
+      })
+      .fetchAll();
+
+    for (const doc of eventDocs) {
+      await events.items.upsert({ ...doc, userId: newName });
+      await events.item(doc.id as string, oldName).delete();
+    }
+
+    // 4. Migrate scores.
+    // Partition key is gameId; id is composite "gameId|userName".
+    const { resources: scoreDocs } = await scores.items
+      .query<Record<string, unknown>>({
+        query: 'SELECT * FROM c WHERE c.userName = @oldName',
+        parameters: [{ name: '@oldName', value: oldName }],
+      })
+      .fetchAll();
+
+    for (const doc of scoreDocs) {
+      const newId = `${doc.gameId as string}|${newName}`;
+      await scores.items.upsert({ ...doc, id: newId, userName: newName });
+      await scores.item(doc.id as string, doc.gameId as string).delete();
+    }
+
+    // 5. Migrate profile document (partition key is id).
+    await profiles.items.upsert({ ...oldProfile, id: newName });
+    await profiles.item(oldName, oldName).delete();
+
+    // 6. Migrate playlists: owner, members[], and track addedBy fields.
+    // Single query covers owned, member, and track-addedBy cases.
+    const { resources: playlistDocs } = await playlists.items
+      .query<Record<string, unknown>>({
+        query: `SELECT * FROM c
+                WHERE c.owner = @oldName
+                   OR ARRAY_CONTAINS(c.members, @oldName)
+                   OR EXISTS(SELECT 1 FROM t IN c.tracks WHERE t.addedBy = @oldName)`,
+        parameters: [{ name: '@oldName', value: oldName }],
+      })
+      .fetchAll();
+
+    for (const pl of playlistDocs) {
+      const updated = {
+        ...pl,
+        owner: pl.owner === oldName ? newName : pl.owner,
+        members: Array.isArray(pl.members)
+          ? (pl.members as string[]).map(m => (m === oldName ? newName : m))
+          : pl.members,
+        tracks: Array.isArray(pl.tracks)
+          ? (pl.tracks as Record<string, unknown>[]).map(t =>
+              t.addedBy === oldName ? { ...t, addedBy: newName } : t
+            )
+          : pl.tracks,
+      };
+      await playlists.items.upsert(updated);
+    }
+
+    context.log(
+      `[rename-user] "${oldName}" → "${newName}": ` +
+      `${eventDocs.length} events, ${scoreDocs.length} scores, ${playlistDocs.length} playlists`,
+    );
+
+    return {
+      status: 200,
+      jsonBody: { ok: true, counts: { events: eventDocs.length, scores: scoreDocs.length, playlists: playlistDocs.length } },
+      headers: corsHeaders,
+    };
+  } catch (err) {
+    context.error('[rename-user] failed:', err);
+    return { status: 500, jsonBody: { error: String(err) }, headers: corsHeaders };
+  }
+}
+
+app.http('rename-user', {
+  methods: ['POST'],
+  route: 'profile/rename',
+  authLevel: 'anonymous',
+  handler: renameUserHandler,
+});

--- a/server/src/shared/gameGenerator.ts
+++ b/server/src/shared/gameGenerator.ts
@@ -183,11 +183,10 @@ function buildBonus(
 }
 
 function itemsOverlap(a: GameItem, b: GameItem): boolean {
-  if (a.category === b.category && a.id === b.id) return true;
+  if (a.category !== b.category) return true;
+  if (a.id === b.id) return true;
   if (a.artistKey && b.artistKey && a.artistKey === b.artistKey) {
-    if (a.category === 'artist' || b.category === 'artist') return true;
-    if (a.category === 'album' && b.category === 'track') return true;
-    if (a.category === 'track' && b.category === 'album') return true;
+    if (a.category === 'artist') return true;
   }
   if (a.albumKey && b.albumKey && a.albumKey === b.albumKey) {
     return true;

--- a/src/auth-entra.ts
+++ b/src/auth-entra.ts
@@ -1,0 +1,87 @@
+import { PublicClientApplication } from '@azure/msal-node';
+import type { SilentFlowRequest, InteractiveRequest } from '@azure/msal-node';
+import { shell } from 'electron';
+import * as fs from 'fs/promises';
+
+export interface EntraUser {
+  oid: string;
+  name: string;
+  email: string;
+}
+
+const SCOPES = ['openid', 'profile', 'email'];
+
+export class EntraAuth {
+  private msalApp: PublicClientApplication;
+  private cacheFile: string;
+
+  constructor(clientId: string, tenantId: string, cacheFile: string) {
+    this.cacheFile = cacheFile;
+    this.msalApp = new PublicClientApplication({
+      auth: {
+        clientId,
+        authority: `https://login.microsoftonline.com/${tenantId}`,
+      },
+      cache: {
+        cachePlugin: {
+          beforeCacheAccess: async (ctx) => {
+            try {
+              const data = await fs.readFile(cacheFile, 'utf8');
+              ctx.tokenCache.deserialize(data);
+            } catch { /* no cache file yet */ }
+          },
+          afterCacheAccess: async (ctx) => {
+            if (ctx.cacheHasChanged) {
+              await fs.writeFile(cacheFile, ctx.tokenCache.serialize(), 'utf8');
+            }
+          },
+        },
+      },
+    });
+  }
+
+  async acquireTokenSilent(): Promise<EntraUser | null> {
+    const accounts = await this.msalApp.getTokenCache().getAllAccounts();
+    if (accounts.length === 0) return null;
+    try {
+      const req: SilentFlowRequest = { scopes: SCOPES, account: accounts[0] };
+      const result = await this.msalApp.acquireTokenSilent(req);
+      return this.extractUser(result);
+    } catch {
+      return null;
+    }
+  }
+
+  async acquireTokenInteractive(prompt?: string): Promise<EntraUser> {
+    // Open the system browser (Edge on Windows — enrolled/compliant for CA policies)
+    // rather than an Electron BrowserWindow which has no device compliance context.
+    // MSAL-node starts a loopback server and handles the redirect automatically.
+    const req: InteractiveRequest = {
+      scopes: SCOPES,
+      openBrowser: async (url: string) => { await shell.openExternal(url); },
+      successTemplate: '<h1>Signed in to TrueTunes!</h1><p>You can close this tab and return to the app.</p>',
+      errorTemplate: '<h1>Sign-in failed</h1><p>{errorMessage}</p><p>You can close this tab.</p>',
+      ...(prompt ? { prompt } : {}),
+    };
+    const result = await this.msalApp.acquireTokenInteractive(req);
+    return this.extractUser(result);
+  }
+
+  async signOut(): Promise<void> {
+    const accounts = await this.msalApp.getTokenCache().getAllAccounts();
+    for (const account of accounts) {
+      await this.msalApp.getTokenCache().removeAccount(account);
+    }
+    try { await fs.unlink(this.cacheFile); } catch { /* ignore */ }
+  }
+
+  private extractUser(result: import('@azure/msal-node').AuthenticationResult | null): EntraUser {
+    if (!result) throw new Error('MSAL returned null result');
+    const claims = result.idTokenClaims as Record<string, unknown> | undefined;
+    const oid = ((claims?.oid ?? claims?.sub) as string | undefined) ?? '';
+    const name = ((claims?.name ?? result.account?.name) as string | undefined) ?? '';
+    const email = (result.account?.username ?? (claims?.email ?? claims?.preferred_username) as string | undefined) ?? '';
+    if (!oid) throw new Error('Entra token missing oid claim');
+    return { oid, name, email };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ loadEnv(); // loads .env from cwd (repo root) in dev; no-op if file absent
 import { app, BrowserWindow, ipcMain, safeStorage, session, shell, Menu, IpcMainInvokeEvent } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { officePubSub } from './pubsub';
+import { EntraAuth } from './auth-entra';
+import type { EntraUser } from './auth-entra';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { readFileSync } from 'fs';
@@ -39,6 +41,12 @@ interface AppConfig {
   queueId?: string;
   /** Display name shown on tracks this user adds to the queue. */
   displayName?: string;
+  /** Entra ID object ID — stable identity tied to the org account. */
+  entraOid?: string;
+  /** Display name sourced from Entra — separate from the user-customisable displayName. */
+  entraName?: string;
+  /** Email address from Entra. */
+  entraEmail?: string;
   /** Last app version the user opened — used to detect first launch on a new version. */
   lastSeenVersion?: string;
   /** Width (px) of the docked queue column. */
@@ -70,6 +78,9 @@ async function loadConfig(): Promise<void> {
     const parsed = JSON.parse(raw) as Partial<AppConfig>;
     // Only load the fields we explicitly persist (not runtime-discovered ones)
     if (typeof parsed.displayName === 'string') config.displayName = parsed.displayName;
+    if (typeof parsed.entraOid === 'string') config.entraOid = parsed.entraOid;
+    if (typeof parsed.entraName === 'string') config.entraName = parsed.entraName;
+    if (typeof parsed.entraEmail === 'string') config.entraEmail = parsed.entraEmail;
     if (typeof parsed.lastSeenVersion === 'string') config.lastSeenVersion = parsed.lastSeenVersion;
     if (typeof parsed.preferredCoordinatorId === 'string') config.preferredCoordinatorId = parsed.preferredCoordinatorId;
     if (typeof parsed.queueDockedWidth === 'number') config.queueDockedWidth = parsed.queueDockedWidth;
@@ -83,6 +94,9 @@ async function saveConfig(): Promise<void> {
     // Only persist non-sensitive, user-set fields
     const toSave: Partial<AppConfig> = {
       displayName: config.displayName,
+      entraOid: config.entraOid,
+      entraName: config.entraName,
+      entraEmail: config.entraEmail,
       lastSeenVersion: config.lastSeenVersion,
       preferredCoordinatorId: config.preferredCoordinatorId,
       queueDockedWidth: config.queueDockedWidth,
@@ -1001,7 +1015,7 @@ function createAuthWindow(): void {
   session.defaultSession.webRequest.onCompleted({ urls: [`${BASE_URL}/api/content/*`] }, (details) => {
     if (details.statusCode === 200 && authWin) {
       log('[auth] /api/content/ 200 — auth confirmed');
-      onAuthReady();
+      void onAuthReady();
     }
   });
 
@@ -1063,12 +1077,91 @@ async function initPubSub(): Promise<void> {
   }
 }
 
-function onAuthReady(): void {
+// ─── Name claim ──────────────────────────────────────────────────────────────
+
+/** Returns true if the name is already owned by a different Entra OID. */
+async function claimDisplayName(oid: string, displayName: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${PUBSUB_FUNCTION_URL}/api/profile/claim`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ oid, displayName }),
+    });
+    return res.status === 409;
+  } catch {
+    return false; // network failure → allow gracefully
+  }
+}
+
+/** Returns the display name linked to this OID in Cosmos, or null if none. */
+async function lookupProfileByOid(oid: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${PUBSUB_FUNCTION_URL}/api/profile/lookup?oid=${encodeURIComponent(oid)}`);
+    if (res.status === 404) return null;
+    if (!res.ok) return null;
+    const data = await res.json() as { displayName?: string };
+    return data.displayName ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Entra auth ───────────────────────────────────────────────────────────────
+
+let entraAuth: EntraAuth | null = null;
+
+async function ensureEntraAuth(forcePrompt?: string): Promise<void> {
+  // Lazy-init so env vars are guaranteed to be loaded (dotenv + build-env.json
+  // run during app startup, before this function is ever called).
+  if (!entraAuth) {
+    const clientId = process.env['ENTRA_CLIENT_ID'];
+    const tenantId = process.env['ENTRA_TENANT_ID'];
+    if (!clientId || !tenantId) {
+      console.warn('[entra] ENTRA_CLIENT_ID / ENTRA_TENANT_ID not set — skipping Entra auth');
+      return;
+    }
+    const cacheFile = path.join(app.getPath('userData'), 'msal-cache.json');
+    entraAuth = new EntraAuth(clientId, tenantId, cacheFile);
+  }
+
+  let user: EntraUser | null = forcePrompt ? null : await entraAuth.acquireTokenSilent();
+  if (!user) {
+    user = await entraAuth.acquireTokenInteractive(forcePrompt);
+  }
+
+  config.entraOid = user.oid;
+  config.entraName = user.name;
+  config.entraEmail = user.email;
+
+  if (!config.displayName) {
+    // No local display name — check Cosmos for an existing profile tied to this OID.
+    const existing = await lookupProfileByOid(user.oid);
+    config.displayName = existing ?? user.name;
+  }
+
+  // Register this display name under this OID (no-op if already claimed; migrates pre-Entra users).
+  claimDisplayName(user.oid, config.displayName).catch(() => {});
+
+  await saveConfig();
+
+  telemetry.setContext({ userId: config.displayName });
+  log('[entra] Authenticated as', user.email, '→', config.displayName);
+  broadcastToRenderers('auth:entra-ready', user);
+}
+
+async function onAuthReady(): Promise<void> {
   if (authConfirmed) return; // fire only once per login
   authConfirmed = true;
   telemetry.event('auth_success');
 
   authWin?.hide();
+
+  try {
+    await ensureEntraAuth();
+  } catch (err) {
+    console.error('[entra] Auth failed:', err);
+    telemetry.exception(err, { phase: 'entra_auth' });
+  }
 
   if (!uiWin) {
     createUIWindow();
@@ -1218,12 +1311,39 @@ ipcMain.handle('win:is-maximized', () => uiWin?.isMaximized() ?? false);
 
 ipcMain.handle('config:getDisplayName', () => config.displayName ?? null);
 
-ipcMain.handle('config:setDisplayName', async (_: IpcMainInvokeEvent, name: string) => {
+ipcMain.handle('config:setDisplayName', async (_: IpcMainInvokeEvent, name: string): Promise<{ error: string } | null> => {
+  // Guard empty name (sign-out path) — skip claim check.
+  if (name && config.entraOid) {
+    const taken = await claimDisplayName(config.entraOid, name);
+    if (taken) return { error: 'taken' };
+  }
   config.displayName = name;
   telemetry.setContext({ userId: name });
   await saveConfig();
-  // Start pubsub now that we have a name (first-time setup path)
   initPubSub().catch(console.error);
+  return null;
+});
+
+ipcMain.handle('auth:getEntraUser', (): EntraUser | null => {
+  if (!config.entraOid) return null;
+  return { oid: config.entraOid, name: config.entraName ?? '', email: config.entraEmail ?? '' };
+});
+
+ipcMain.handle('auth:entraSignOut', async () => {
+  await entraAuth?.signOut();
+  config.entraOid = undefined;
+  config.entraName = undefined;
+  config.entraEmail = undefined;
+  config.displayName = undefined;
+  await saveConfig();
+});
+
+ipcMain.handle('auth:entraReLogin', async () => {
+  try {
+    await ensureEntraAuth('select_account');
+  } catch (err) {
+    console.error('[entra] Re-login failed:', err);
+  }
 });
 
 ipcMain.handle('config:getQueueDockedWidth', () => config.queueDockedWidth ?? 380);
@@ -1371,6 +1491,27 @@ ipcMain.handle('profile:uploadImage', async (_: IpcMainInvokeEvent, userName: st
       body: Buffer.from(data),
     });
     return await res.json();
+  } catch (err) {
+    return { error: String(err) };
+  }
+});
+
+ipcMain.handle('profile:rename', async (_: IpcMainInvokeEvent, oldName: string, newName: string): Promise<{ ok?: boolean; error?: string }> => {
+  if (!config.entraOid) return { error: 'not-authed' };
+  try {
+    const res = await fetch(`${PUBSUB_FUNCTION_URL}/api/profile/rename`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ oid: config.entraOid, oldName, newName }),
+    });
+    if (res.status === 409) return { error: 'taken' };
+    if (res.status === 403) return { error: 'not-owner' };
+    if (!res.ok) return { error: `server error ${res.status}` };
+    config.displayName = newName;
+    telemetry.setContext({ userId: newName });
+    await saveConfig();
+    initPubSub().catch(console.error);
+    return { ok: true };
   } catch (err) {
     return { error: String(err) };
   }
@@ -2053,11 +2194,8 @@ app.whenReady().then(async () => {
   if (storedToken && (await validateSessionToken(storedToken))) {
     sessionToken = storedToken;
     log('[auth] Restored session from storage');
-    authConfirmed = true;
     telemetry.event('app_started', { sessionRestored: true, appVersion: app.getVersion() });
-    createUIWindow();
-    connectWebSocket().catch(console.error);
-    initPubSub().catch(console.error);
+    void onAuthReady();
   } else {
     if (storedToken) await clearSessionToken(); // clear invalid token
     telemetry.event('app_started', { sessionRestored: false, appVersion: app.getVersion() });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1914,6 +1914,44 @@ ipcMain.handle('genius:artist', async (_: IpcMainInvokeEvent, artistName: string
   }
 });
 
+ipcMain.handle('genius:albumYear', async (_: IpcMainInvokeEvent, albumName: string, artistName: string) => {
+  const key = process.env.GENIUS_ACCESS_TOKEN;
+  if (!key) {
+    log('[genius] GENIUS_ACCESS_TOKEN not set — skipping albumYear');
+    return null;
+  }
+
+  const debugReq = (id: string, url: string, ts: number) =>
+    httpDebugWin?.webContents.send('http:req', { id, ts, operationId: 'genius:albumYear', method: 'GET', url, headers: { Authorization: 'Bearer ***' } });
+  const debugRes = (id: string, status: number, body: string, ts: number) =>
+    httpDebugWin?.webContents.send('http:res', { id, status, statusText: String(status), headers: {}, body, durationMs: Date.now() - ts });
+
+  try {
+    const searchUrl = `https://api.genius.com/search?q=${encodeURIComponent(`${albumName} ${artistName}`)}`;
+    const searchId = randomUUID(); const searchTs = Date.now();
+    debugReq(searchId, searchUrl, searchTs);
+    const searchRes = await fetch(searchUrl, { headers: { Authorization: `Bearer ${key}` } });
+    const searchBody = await searchRes.text();
+    debugRes(searchId, searchRes.status, searchBody, searchTs);
+    if (!searchRes.ok) return null;
+
+    type Hit = {
+      result: {
+        primary_artist: { name: string } | null;
+        release_date_components: { year: number | null } | null;
+      };
+    };
+    const searchData = JSON.parse(searchBody) as { response: { hits: Hit[] } };
+    const hits = searchData.response?.hits ?? [];
+    const lower = artistName.toLowerCase();
+    const hit = hits.find((h) => h.result.primary_artist?.name?.toLowerCase().includes(lower)) ?? hits[0];
+    return hit?.result?.release_date_components?.year ?? null;
+  } catch (err) {
+    log(`[genius] albumYear error: ${err}`);
+    return null;
+  }
+});
+
 // ─── Application menu ────────────────────────────────────────────────────────
 
 function buildMenu(): void {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import type { FetchRequest, FetchResponse, AttributionMap, AttributionEvent } from './types';
+import type { EntraUser } from './auth-entra';
 
 type VoidCallback = () => void;
 type Unsubscribe = () => void;
@@ -39,7 +40,7 @@ export interface SonosAPI {
   clearQueue: () => Promise<unknown>;
   // Attribution / office presence
   getDisplayName: () => Promise<string | null>;
-  setDisplayName: (name: string) => Promise<void>;
+  setDisplayName: (name: string) => Promise<{ error: string } | null>;
   getQueueDockedWidth: () => Promise<number>;
   setQueueDockedWidth: (width: number) => Promise<void>;
   publishQueued: (item: { eventType: 'track' | 'album'; uri: string; trackName: string; artist: string; serviceId?: string; accountId?: string; artistId?: string; album?: string; albumId?: string; imageUrl?: string }) => Promise<void>;
@@ -76,6 +77,11 @@ export interface SonosAPI {
   fetchUsers: () => Promise<unknown>;
   fetchUserProfile: (userName: string) => Promise<unknown>;
   uploadProfileImage: (userName: string, data: ArrayBuffer, mimeType: string) => Promise<unknown>;
+  getEntraUser: () => Promise<EntraUser | null>;
+  entraSignOut: () => Promise<void>;
+  entraReLogin: () => Promise<void>;
+  onEntraReady: (cb: (user: EntraUser) => void) => Unsubscribe;
+  renameUser: (oldName: string, newName: string) => Promise<{ ok?: boolean; error?: string }>;
   minimizeWindow:    () => Promise<void>;
   maximizeWindow:    () => Promise<void>;
   closeWindow:       () => Promise<void>;
@@ -90,6 +96,7 @@ let _authReady = false;
 let _wsReady = false;
 let _wsGroups: unknown[] | null = null;
 let _attributionMap: AttributionMap | null = null;
+let _entraUser: EntraUser | null = null;
 
 ipcRenderer.on('auth:ready', () => {
   _authReady = true;
@@ -105,6 +112,9 @@ ipcRenderer.on('ws:groups', (_e, groups: unknown[]) => {
 });
 ipcRenderer.on('attribution:map', (_e, map: AttributionMap) => {
   _attributionMap = map;
+});
+ipcRenderer.on('auth:entra-ready', (_e, user: EntraUser) => {
+  _entraUser = user;
 });
 
 contextBridge.exposeInMainWorld('sonos', {
@@ -228,4 +238,14 @@ contextBridge.exposeInMainWorld('sonos', {
   fetchUsers: () => ipcRenderer.invoke('users:list'),
   fetchUserProfile: (userName) => ipcRenderer.invoke('profile:get', userName),
   uploadProfileImage: (userName, data, mimeType) => ipcRenderer.invoke('profile:uploadImage', userName, data, mimeType),
+  getEntraUser: () => ipcRenderer.invoke('auth:getEntraUser'),
+  entraSignOut: () => ipcRenderer.invoke('auth:entraSignOut'),
+  entraReLogin: () => ipcRenderer.invoke('auth:entraReLogin'),
+  onEntraReady: (cb: (user: EntraUser) => void): Unsubscribe => {
+    if (_entraUser !== null) cb(_entraUser);
+    const listener = (_e: unknown, user: EntraUser) => cb(user);
+    ipcRenderer.on('auth:entra-ready', listener);
+    return () => ipcRenderer.removeListener('auth:entra-ready', listener);
+  },
+  renameUser: (oldName: string, newName: string) => ipcRenderer.invoke('profile:rename', oldName, newName),
 } satisfies SonosAPI);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -60,6 +60,7 @@ export interface SonosAPI {
   fetchRecentlyPlayed: (userId: string) => Promise<unknown>;
   geniusDescription: (trackName: string, artistName: string) => Promise<string | null>;
   geniusArtist: (artistName: string, trackHint?: string) => Promise<unknown>;
+  geniusAlbumYear: (albumName: string, artistName: string) => Promise<number | null>;
   trackEvent: (name: string, properties?: Record<string, string>) => Promise<void>;
   fetchPlaylists: (filter: { owner?: string; member?: string }) => Promise<unknown>;
   fetchPlaylist: (id: string) => Promise<unknown>;
@@ -194,6 +195,8 @@ contextBridge.exposeInMainWorld('sonos', {
     ipcRenderer.invoke('genius:description', trackName, artistName),
   geniusArtist: (artistName: string, trackHint?: string) =>
     ipcRenderer.invoke('genius:artist', artistName, trackHint),
+  geniusAlbumYear: (albumName: string, artistName: string) =>
+    ipcRenderer.invoke('genius:albumYear', albumName, artistName),
   trackEvent: (name: string, properties?: Record<string, string>) =>
     ipcRenderer.invoke('telemetry:event', name, properties),
   minimizeWindow:    () => ipcRenderer.invoke('win:minimize'),


### PR DESCRIPTION
## What's new

### Entra ID authentication
- All users are now tied to their True North IT organisation account — no more throwaway accounts
- Silent sign-in on launch; system browser (Edge) handles the login flow, satisfying the Conditional Access policy
- Existing users keep their chosen display names; new users default to their Entra display name
- Sign-out from the profile page clears the Entra session and prompts account selection on next launch

### Profile page — name management
- **Change name** button with inline rename; migrates all stats, scores, playlist ownership, and queue attribution to the new name in Cosmos
- Display name uniqueness enforced across the team via the `claim-name` Azure Function


### Azure Functions (new endpoints)
- `POST /api/profile/claim` — link a display name to an Entra OID
- `POST /api/profile/rename` — bulk migrate all Cosmos data to a new display name
- `GET /api/profile/lookup` — resolve an Entra OID to an existing display name

