### PR TITLE
Skinny side-panel mode

### DIFF
--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -33,6 +33,8 @@ import { ContainerPanel } from './components/ContainerPanel';
 import { LeaderboardPanel } from './components/LeaderboardPanel';
 import { QueuedlePanel } from './components/queuedle/QueuedlePanel';
 import { QueueSidebar, type QueueSidebarHandle } from './components/queue/QueueSidebar';
+import { SkinnyShell } from './components/skinny/SkinnyShell';
+import { useSkinnyMode } from './hooks/useSkinnyMode';
 import { MiniPlayerShell } from './components/MiniPlayer';
 import { FeedbackDialog } from './components/FeedbackDialog';
 import { ChangelogDialog } from './components/ChangelogDialog';
@@ -93,6 +95,7 @@ function MainApp() {
   const [queueDockedWidth, setQueueDockedWidth] = useState<number>(380);
   const queueSidebarRef = useRef<QueueSidebarHandle>(null);
   const shellRef = useRef<HTMLDivElement>(null);
+  const skinny = useSkinnyMode();
   const handleResizeWidthLive = useCallback((width: number) => {
     shellRef.current?.style.setProperty('--docked-queue-w', `${width}px`);
   }, []);
@@ -423,12 +426,26 @@ useEffect(() => {
   return (
     <ToastProvider>
     <ContextMenuProvider displayName={displayName} onAddToQueue={handleAddToQueue}>
+    <Splash ready={splashReady} />
+    {skinny ? (
+      <SkinnyShell
+        isAuthed={isAuthed}
+        playback={playback}
+        queueItems={queueItems}
+        setQueueItems={setQueueItems}
+        queueLoading={queueLoading}
+        queueError={queueError}
+        reloadQueue={reloadQueue}
+        showToast={showToast}
+        groups={groups}
+        activeGroupId={activeGroupId}
+      />
+    ) : (
     <div
       ref={shellRef}
       className={styles.shell}
       style={{ '--docked-queue-w': `${queueDockedWidth}px` } as React.CSSProperties}
     >
-      <Splash ready={splashReady} />
       <TopNav
         isAuthed={isAuthed}
         groups={groups}
@@ -504,15 +521,16 @@ useEffect(() => {
         onShuffle={reloadQueue}
         displayName={displayName}
       />
-      {toastMsg && <div className={styles.toast}>{toastMsg}</div>}
-      {entraLoading && (
-        <div className={styles.entraSigningIn}>
-          <span>Signing in with your organisation account…</span>
-        </div>
-      )}
-      {feedbackOpen && <FeedbackDialog onClose={() => setFeedbackOpen(false)} />}
-      {changelogOpen && <ChangelogDialog onClose={() => setChangelogOpen(false)} />}
     </div>
+    )}
+    {toastMsg && <div className={styles.toast}>{toastMsg}</div>}
+    {entraLoading && (
+      <div className={styles.entraSigningIn}>
+        <span>Signing in with your organisation account…</span>
+      </div>
+    )}
+    {feedbackOpen && <FeedbackDialog onClose={() => setFeedbackOpen(false)} />}
+    {changelogOpen && <ChangelogDialog onClose={() => setChangelogOpen(false)} />}
     </ContextMenuProvider>
     </ToastProvider>
   );

--- a/renderer/src/components/queue/QueueSidebar.tsx
+++ b/renderer/src/components/queue/QueueSidebar.tsx
@@ -28,6 +28,8 @@ interface Props {
   dockedWidth?: number;
   onResizeWidth?: (width: number) => void;
   onResizeWidthLive?: (width: number) => void;
+  /** 'docked' = resizable sidebar pinned to the right; 'skinny' = full-width panel, no resize. */
+  variant?: 'docked' | 'skinny';
 }
 
 export interface QueueSidebarHandle {
@@ -55,6 +57,7 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
     dockedWidth,
     onResizeWidth,
     onResizeWidthLive,
+    variant = 'docked',
   },
   ref
 ) {
@@ -271,19 +274,22 @@ export const QueueSidebar = forwardRef<QueueSidebarHandle, Props>(function Queue
   }
 
   const selCount = selected.size;
-  const sidebarClass = styles.sidebar;
-  const sidebarStyle = { width: liveWidth };
+  const isSkinny = variant === 'skinny';
+  const sidebarClass = isSkinny ? `${styles.sidebar} ${styles.skinny}` : styles.sidebar;
+  const sidebarStyle = isSkinny ? undefined : { width: liveWidth };
 
   return (
     <div className={sidebarClass} style={sidebarStyle}>
-      <div
-        className={styles.resizeHandle}
-        onPointerDown={handleResizePointerDown}
-        onPointerMove={e => e.currentTarget.style.setProperty('--mouse-y', `${e.nativeEvent.offsetY}px`)}
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="Resize queue"
-      />
+      {!isSkinny && (
+        <div
+          className={styles.resizeHandle}
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={e => e.currentTarget.style.setProperty('--mouse-y', `${e.nativeEvent.offsetY}px`)}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize queue"
+        />
+      )}
       <div className={styles.dockedTopBar}>
         <div className={styles.winPill}>
           <WindowControls />

--- a/renderer/src/components/skinny/SkinnyShell.tsx
+++ b/renderer/src/components/skinny/SkinnyShell.tsx
@@ -1,0 +1,69 @@
+import type React from 'react';
+import type { usePlayback } from '../../hooks/usePlayback';
+import { useNowPlaying } from '../../hooks/useNowPlaying';
+import type { NormalizedQueueItem, NormalizedGroup } from '../../types/provider';
+import { QueueSidebar } from '../queue/QueueSidebar';
+import { SkinnyTransport } from './SkinnyTransport';
+import styles from '../../styles/SkinnyShell.module.css';
+
+interface Props {
+  isAuthed: boolean;
+  playback: ReturnType<typeof usePlayback>['playback'];
+  queueItems: NormalizedQueueItem[];
+  setQueueItems: (updater: NormalizedQueueItem[] | ((prev: NormalizedQueueItem[]) => NormalizedQueueItem[])) => void;
+  queueLoading: boolean;
+  queueError: string | null;
+  reloadQueue: () => void;
+  showToast: (msg: string) => void;
+  groups: NormalizedGroup[];
+  activeGroupId: string | null;
+}
+
+/**
+ * Skinny side-panel layout: just the queue (full width) plus a condensed
+ * transport strip at the bottom. No nav, no search, no browse panels.
+ * Shown automatically when the window is narrower than FULL_MIN.
+ */
+export function SkinnyShell({
+  isAuthed,
+  playback,
+  queueItems,
+  setQueueItems,
+  queueLoading,
+  queueError,
+  reloadQueue,
+  showToast,
+  groups,
+  activeGroupId,
+}: Props) {
+  const np = useNowPlaying(playback);
+
+  // Ambient dominant-colour glow centred around the middle of the panel,
+  // fading out toward the top and bottom — keeps the app's glow-y aesthetic.
+  const shellStyle: React.CSSProperties | undefined = np.dominantColor
+    ? {
+        background: `radial-gradient(135% 70% at 50% 50%, rgba(${np.dominantColor}, 0.30) 0%, rgba(${np.dominantColor}, 0.11) 48%, transparent 85%), var(--bg)`,
+      }
+    : undefined;
+
+  return (
+    <div className={styles.shell} style={shellStyle}>
+      <QueueSidebar
+        variant="skinny"
+        items={queueItems}
+        setItems={setQueueItems}
+        isLoading={queueLoading}
+        error={queueError}
+        currentObjectId={playback.currentObjectId}
+        currentQueueItemId={playback.queueItemId}
+        positionMs={playback.positionMs}
+        currentTrackDurationMs={playback.durationMs}
+        groupName={groups.find(g => g.id === activeGroupId)?.name ?? null}
+        onRefresh={reloadQueue}
+        onError={showToast}
+        onAddToQueue={() => {}}
+      />
+      <SkinnyTransport np={np} isAuthed={isAuthed} />
+    </div>
+  );
+}

--- a/renderer/src/components/skinny/SkinnyTransport.tsx
+++ b/renderer/src/components/skinny/SkinnyTransport.tsx
@@ -1,0 +1,84 @@
+import type React from 'react';
+import { SkipBack, Play, Pause, SkipForward } from 'lucide-react';
+import { getActiveProvider } from '../../providers';
+import type { useNowPlaying } from '../../hooks/useNowPlaying';
+import styles from '../../styles/SkinnyTransport.module.css';
+
+interface Props {
+  np: ReturnType<typeof useNowPlaying>;
+  isAuthed: boolean;
+}
+
+/**
+ * Condensed now-playing + transport strip for skinny side-panel mode.
+ * The dominant-colour glow lives on the panel background (SkinnyShell); this bar
+ * keeps the full PlayerBar's neutral white now-playing look. Three core buttons:
+ * prev / play-pause / next.
+ */
+export function SkinnyTransport({ np, isAuthed }: Props) {
+  const {
+    displayTrack, displayArtist, cachedArt, progressPct, durationMs,
+    isPlaying, elapsedLabel, durationLabel,
+  } = np;
+
+  const refresh = () => getActiveProvider().refreshPlayback();
+
+  const handleSeek = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!durationMs) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    getActiveProvider().seek(Math.floor(pct * durationMs)).then(refresh);
+  };
+
+  return (
+    <div className={styles.bar}>
+      <div className={styles.art}>
+        {cachedArt ? <img src={cachedArt} alt="" /> : <div className={styles.artPh}>♪</div>}
+      </div>
+
+      <div className={styles.info}>
+        <div className={styles.title}>{displayTrack || '—'}</div>
+        <div className={styles.artist}>{displayArtist || ''}</div>
+        <div
+          className={styles.progress}
+          onClick={handleSeek}
+          role="progressbar"
+          aria-valuenow={progressPct}
+        >
+          <div className={styles.progressFill} style={{ width: `${progressPct}%` }} />
+        </div>
+        <div className={styles.timeRow}>
+          <span>{elapsedLabel}</span>
+          <span>{durationLabel}</span>
+        </div>
+      </div>
+
+      <div className={styles.controls}>
+        <button
+          className={styles.btn}
+          disabled={!isAuthed}
+          onClick={() => getActiveProvider().skipPrev().then(refresh)}
+          title="Previous"
+        >
+          <SkipBack size={14} />
+        </button>
+        <button
+          className={`${styles.btn} ${styles.playBtn}`}
+          disabled={!isAuthed}
+          onClick={() => (isPlaying ? getActiveProvider().pause() : getActiveProvider().play()).then(refresh)}
+          title={isPlaying ? 'Pause' : 'Play'}
+        >
+          {isPlaying ? <Pause size={15} /> : <Play size={15} />}
+        </button>
+        <button
+          className={styles.btn}
+          disabled={!isAuthed}
+          onClick={() => getActiveProvider().skipNext().then(refresh)}
+          title="Next"
+        >
+          <SkipForward size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/renderer/src/hooks/useSkinnyMode.ts
+++ b/renderer/src/hooks/useSkinnyMode.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+// Width below which the full layout no longer fits and the renderer collapses
+// to the skinny side-panel layout (queue + condensed transport only).
+// Matches the player bar (800) + min queue (280) + padding that the full layout
+// needs — kept in sync with src/main.ts's old minWidth.
+export const FULL_MIN = 864 + 280; // 1144
+
+// Hysteresis: once skinny, don't pop back to full until comfortably past the
+// threshold, so dragging right at the boundary doesn't flicker between layouts.
+const EXIT_BUFFER = 40;
+
+/** Returns true when the window is narrow enough to use the skinny side-panel layout. */
+export function useSkinnyMode(): boolean {
+  const [skinny, setSkinny] = useState(() => window.innerWidth < FULL_MIN);
+
+  useEffect(() => {
+    function onResize() {
+      const w = window.innerWidth;
+      setSkinny((prev) => (prev ? w <= FULL_MIN + EXIT_BUFFER : w < FULL_MIN));
+    }
+    window.addEventListener('resize', onResize);
+    onResize();
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  return skinny;
+}

--- a/renderer/src/styles/QueueSidebar.module.css
+++ b/renderer/src/styles/QueueSidebar.module.css
@@ -15,6 +15,14 @@
   z-index: 200;
 }
 
+/* Skinny side-panel mode — fills the whole window width, no docking/resize. */
+.sidebar.skinny {
+  width: 100%;
+  margin-left: 0;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 /* Top strip in docked mode — hosts window controls; aligns with TopNav height
    so the visual horizon across the app stays consistent. */
 .dockedTopBar {

--- a/renderer/src/styles/SkinnyShell.module.css
+++ b/renderer/src/styles/SkinnyShell.module.css
@@ -1,0 +1,9 @@
+/* Full-window skinny side-panel layout: queue fills the height, condensed
+   transport strip pinned at the bottom. */
+.shell {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}

--- a/renderer/src/styles/SkinnyTransport.module.css
+++ b/renderer/src/styles/SkinnyTransport.module.css
@@ -1,0 +1,141 @@
+/* Condensed transport strip docked at the bottom of the skinny side panel.
+   Transparent so the panel's dominant-colour glow shows through; the
+   now-playing text/progress stay neutral white like the full PlayerBar. */
+.bar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: transparent;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* ── Album art ── */
+.art {
+  width: 52px;
+  height: 52px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.40);
+}
+.art img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.artPh {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  color: rgba(255, 255, 255, 0.25);
+}
+
+/* ── Track info + progress ── */
+.info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: 0.01em;
+}
+.artist {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.progress {
+  margin-top: 3px;
+  height: 11px;
+  position: relative;
+  cursor: pointer;
+  background: transparent;
+}
+.progress::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 3px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.10);
+  transition: height 0.15s;
+  pointer-events: none;
+}
+.progress:hover::before { height: 5px; }
+.progressFill {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 3px;
+  border-radius: 2px;
+  background: #fff;
+  transition: width 0.5s linear, height 0.15s, background 0.15s;
+  pointer-events: none;
+}
+.progress:hover .progressFill {
+  height: 5px;
+  background: #1db954;
+}
+.timeRow {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2px;
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.35);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+/* ── Controls ── */
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: none;
+  color: rgba(255, 255, 255, 0.70);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.12s, color 0.12s;
+}
+.btn:hover  { background: rgba(255, 255, 255, 0.12); color: #fff; }
+.btn:active { background: rgba(255, 255, 255, 0.20); }
+.btn:disabled { opacity: 0.4; cursor: default; }
+
+.playBtn {
+  width: 36px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+}
+.playBtn:hover { background: rgba(255, 255, 255, 0.22); }

--- a/renderer/src/test/setup.ts
+++ b/renderer/src/test/setup.ts
@@ -8,6 +8,11 @@ import { vi } from 'vitest';
   disconnect() {}
 };
 
+// jsdom defaults innerWidth to 1024, which is below the skinny-mode breakpoint
+// (FULL_MIN = 1144) and would make the app render the skinny side-panel layout.
+// Use the app's real default window width so tests exercise the full layout.
+window.innerWidth = 1280;
+
 const noop = () => () => {};
 const pending = () => new Promise<never>(() => {});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1231,7 +1231,10 @@ function createUIWindow(): void {
   uiWin = new BrowserWindow({
     width: 1280,
     height: 720,
-    minWidth: 864 + 280, // player bar (800) + 32px each side + min queue width
+    // 320 is the skinny side-panel floor. The full layout needs ~1144px
+    // (player bar 800 + queue 280 + padding); below that the renderer collapses
+    // to skinny mode (see useSkinnyMode / FULL_MIN), so we let the window shrink.
+    minWidth: 320,
     minHeight: 480,
     title: `True-Tunes v${app.getVersion()}`,
     backgroundColor: '#1c1c1e',


### PR DESCRIPTION
﻿## Skinny / Side-Panel Mode

A new compact layout for docking True Tunes at the edge of an ultrawide (or any narrow) monitor.

### What's new
- **Skinny side-panel mode** — drag the window narrower than the normal minimum and it automatically collapses to a slim panel showing just the **play queue** and a **condensed transport bar**. Drag it wider again and the full layout returns. No toggle, no menu — it follows the window width.
- **Condensed transport bar** at the bottom of the panel: album art, track/artist, a seekable progress bar, and core **previous / play-pause / next** controls.
- **Ambient glow** — the panel picks up a soft dominant-colour glow from the current track's artwork, keeping the app's signature look in the smaller footprint.
- The queue keeps all its powers in skinny mode: drag-to-reorder, multi-select + delete, clear, and jump-to-now-playing, plus the window controls.

### Notes
- The window can now shrink well below its previous minimum width to make docking possible; above the breakpoint everything looks and works exactly as before.
- Search, browse, and add-to-queue are intentionally hidden in skinny mode — it's a focused now-playing/queue view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
